### PR TITLE
feat: add wearables schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@ src/report/* @decentraland/core-developers
 # team-specific types and schemas
 
 src/dapps/* @decentraland/dapps
+src/platform/* @decentraland/platform

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -450,10 +450,10 @@ export type ValidWorldRange = {
 // @alpha (undocumented)
 export type Wearable = {
     id: string;
-    description: I18N[];
+    descriptions: I18N[];
     collectionAddress: string;
     rarity: Rarity;
-    name: I18N[];
+    names: I18N[];
     data: {
         replaces: WearableCategory[];
         hides: WearableCategory[];

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -149,6 +149,23 @@ export function getChainName(chainId: ChainId): ChainName | null;
 // @alpha
 export function getWorld(): World;
 
+// Warning: (ae-missing-release-tag) "I18N" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "I18N" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type I18N = {
+    code: Locale;
+    text: string;
+};
+
+// @public (undocumented)
+export namespace I18N {
+    const // (undocumented)
+    schema: JSONSchema<I18N>;
+    const // (undocumented)
+    validate: ValidateFunction<I18N>;
+}
+
 // @alpha
 export function isInsideWorldLimits(x: number, y: number): boolean;
 
@@ -207,6 +224,25 @@ export namespace ListingStatus {
     validate: ValidateFunction<ListingStatus>;
 }
 
+// Warning: (ae-missing-release-tag) "Locale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Locale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum Locale {
+    // (undocumented)
+    EN = "en",
+    // (undocumented)
+    ES = "es"
+}
+
+// @public (undocumented)
+export namespace Locale {
+    const // (undocumented)
+    schema: JSONSchema<Locale>;
+    const // (undocumented)
+    validate: ValidateFunction<Locale>;
+}
+
 // @alpha
 export type MetaTransaction = {
     from: string;
@@ -219,6 +255,27 @@ export namespace MetaTransaction {
     schema: JSONSchema<MetaTransaction>;
     const // (undocumented)
     validate: ValidateFunction<MetaTransaction>;
+}
+
+// Warning: (ae-missing-release-tag) "Metrics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Metrics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type Metrics = {
+    triangles: number;
+    materials: number;
+    textures: number;
+    meshes: number;
+    bodies: number;
+    entities: number;
+};
+
+// @public (undocumented)
+export namespace Metrics {
+    const // (undocumented)
+    schema: JSONSchema<Metrics>;
+    const // (undocumented)
+    validate: ValidateFunction<Metrics>;
 }
 
 // @alpha
@@ -399,6 +456,55 @@ export type ValidWorldRange = {
     yMax: number;
 };
 
+// Warning: (ae-missing-release-tag) "Wearable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Wearable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type Wearable = {
+    id: string;
+    description: string;
+    collectionAddress: string;
+    rarity: Rarity;
+    i18n: I18N;
+    data: {
+        replaces: WearableCategory[];
+        hides: WearableCategory[];
+        tags: string[];
+        representations: WearableRepresentation[];
+        category: WearableCategory;
+    };
+    thumbnail: string;
+    image: string;
+    metrics?: Metrics;
+};
+
+// @public (undocumented)
+export namespace Wearable {
+    const // (undocumented)
+    schema: JSONSchema<Wearable>;
+    const // (undocumented)
+    validate: ValidateFunction<Wearable>;
+}
+
+// Warning: (ae-missing-release-tag) "WearableBodyShape" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WearableBodyShape" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum WearableBodyShape {
+    // (undocumented)
+    FEMALE = "urn:decentraland:off-chain:base-avatars:BaseFemale",
+    // (undocumented)
+    MALE = "urn:decentraland:off-chain:base-avatars:BaseMale"
+}
+
+// @public (undocumented)
+export namespace WearableBodyShape {
+    const // (undocumented)
+    schema: JSONSchema<WearableBodyShape>;
+    const // (undocumented)
+    validate: ValidateFunction<WearableBodyShape>;
+}
+
 // Warning: (ae-missing-release-tag) "WearableCategory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "WearableCategory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -442,6 +548,26 @@ export namespace WearableCategory {
     schema: JSONSchema<WearableCategory>;
     const // (undocumented)
     validate: ValidateFunction<WearableCategory>;
+}
+
+// Warning: (ae-missing-release-tag) "WearableRepresentation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WearableRepresentation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type WearableRepresentation = {
+    bodyShapes: WearableBodyShape[];
+    mainFile: string;
+    contents: string[];
+    overrideHides: WearableCategory[];
+    overrideReplaces: WearableCategory[];
+};
+
+// @public (undocumented)
+export namespace WearableRepresentation {
+    const // (undocumented)
+    schema: JSONSchema<WearableRepresentation>;
+    const // (undocumented)
+    validate: ValidateFunction<WearableRepresentation>;
 }
 
 // @alpha

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -149,16 +149,13 @@ export function getChainName(chainId: ChainId): ChainName | null;
 // @alpha
 export function getWorld(): World;
 
-// Warning: (ae-missing-release-tag) "I18N" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "I18N" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export type I18N = {
     code: Locale;
     text: string;
 };
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace I18N {
     const // (undocumented)
     schema: JSONSchema<I18N>;
@@ -224,10 +221,7 @@ export namespace ListingStatus {
     validate: ValidateFunction<ListingStatus>;
 }
 
-// Warning: (ae-missing-release-tag) "Locale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Locale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export enum Locale {
     // (undocumented)
     EN = "en",
@@ -235,7 +229,7 @@ export enum Locale {
     ES = "es"
 }
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace Locale {
     const // (undocumented)
     schema: JSONSchema<Locale>;
@@ -257,10 +251,7 @@ export namespace MetaTransaction {
     validate: ValidateFunction<MetaTransaction>;
 }
 
-// Warning: (ae-missing-release-tag) "Metrics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Metrics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export type Metrics = {
     triangles: number;
     materials: number;
@@ -270,7 +261,7 @@ export type Metrics = {
     entities: number;
 };
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace Metrics {
     const // (undocumented)
     schema: JSONSchema<Metrics>;
@@ -456,16 +447,13 @@ export type ValidWorldRange = {
     yMax: number;
 };
 
-// Warning: (ae-missing-release-tag) "Wearable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "Wearable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export type Wearable = {
     id: string;
-    description: string;
+    description: I18N[];
     collectionAddress: string;
     rarity: Rarity;
-    i18n: I18N;
+    name: I18N[];
     data: {
         replaces: WearableCategory[];
         hides: WearableCategory[];
@@ -478,7 +466,7 @@ export type Wearable = {
     metrics?: Metrics;
 };
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace Wearable {
     const // (undocumented)
     schema: JSONSchema<Wearable>;
@@ -486,10 +474,7 @@ export namespace Wearable {
     validate: ValidateFunction<Wearable>;
 }
 
-// Warning: (ae-missing-release-tag) "WearableBodyShape" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "WearableBodyShape" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export enum WearableBodyShape {
     // (undocumented)
     FEMALE = "urn:decentraland:off-chain:base-avatars:BaseFemale",
@@ -497,7 +482,7 @@ export enum WearableBodyShape {
     MALE = "urn:decentraland:off-chain:base-avatars:BaseMale"
 }
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace WearableBodyShape {
     const // (undocumented)
     schema: JSONSchema<WearableBodyShape>;
@@ -550,10 +535,7 @@ export namespace WearableCategory {
     validate: ValidateFunction<WearableCategory>;
 }
 
-// Warning: (ae-missing-release-tag) "WearableRepresentation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "WearableRepresentation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @alpha (undocumented)
 export type WearableRepresentation = {
     bodyShapes: WearableBodyShape[];
     mainFile: string;
@@ -562,7 +544,7 @@ export type WearableRepresentation = {
     overrideReplaces: WearableCategory[];
 };
 
-// @public (undocumented)
+// @alpha (undocumented)
 export namespace WearableRepresentation {
     const // (undocumented)
     schema: JSONSchema<WearableRepresentation>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,5 @@ export {
   getWorld,
   isInsideWorldLimits,
 } from './dapps/world'
+
+export * from './platform'

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,0 +1,1 @@
+export * from './wearables'

--- a/src/platform/wearables/i18n.ts
+++ b/src/platform/wearables/i18n.ts
@@ -1,0 +1,24 @@
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+import { Locale } from './locale'
+
+export type I18N = {
+  code: Locale;
+  text: string;
+};
+
+export namespace I18N {
+  export const schema: JSONSchema<I18N> = {
+    type: 'object',
+    properties: {
+      code: Locale.schema,
+      text: {
+        type: 'string',
+      },
+    },
+    additionalProperties: false,
+    required: ['code', 'text'],
+
+  }
+
+  export const validate: ValidateFunction<I18N> = generateValidator(schema)
+}

--- a/src/platform/wearables/i18n.ts
+++ b/src/platform/wearables/i18n.ts
@@ -1,11 +1,13 @@
 import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
 import { Locale } from './locale'
 
+/** @alpha */
 export type I18N = {
   code: Locale;
   text: string;
 };
 
+/** @alpha */
 export namespace I18N {
   export const schema: JSONSchema<I18N> = {
     type: 'object',

--- a/src/platform/wearables/index.ts
+++ b/src/platform/wearables/index.ts
@@ -1,0 +1,6 @@
+export { I18N } from './i18n'
+export { Locale } from './locale'
+export { Metrics } from './metrics'
+export { WearableRepresentation } from './representation'
+export { WearableBodyShape } from './wearable-body-shape'
+export { Wearable } from './wearable'

--- a/src/platform/wearables/locale.ts
+++ b/src/platform/wearables/locale.ts
@@ -1,10 +1,12 @@
 import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
 
+/** @alpha */
 export enum Locale {
   EN = 'en',
   ES = 'es'
 }
 
+/** @alpha */
 export namespace Locale {
   export const schema: JSONSchema<Locale> = {
     type: 'string',

--- a/src/platform/wearables/locale.ts
+++ b/src/platform/wearables/locale.ts
@@ -1,0 +1,15 @@
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+
+export enum Locale {
+  EN = 'en',
+  ES = 'es'
+}
+
+export namespace Locale {
+  export const schema: JSONSchema<Locale> = {
+    type: 'string',
+    enum: Object.values(Locale),
+  }
+
+  export const validate: ValidateFunction<Locale> = generateValidator(schema)
+}

--- a/src/platform/wearables/metrics.ts
+++ b/src/platform/wearables/metrics.ts
@@ -1,0 +1,42 @@
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+
+export type Metrics = {
+  triangles: number
+  materials: number
+  textures: number
+  meshes: number
+  bodies: number
+  entities: number
+}
+
+export namespace Metrics {
+  export const schema: JSONSchema<Metrics> = {
+    type: 'object',
+    properties: {
+      triangles: {
+        type: 'number',
+      },
+      materials: {
+        type: 'number',
+      },
+      textures: {
+        type: 'number',
+      },
+      meshes: {
+        type: 'number',
+      },
+      bodies: {
+        type: 'number',
+      },
+      entities: {
+        type: 'number',
+      },
+    },
+    additionalProperties: false,
+    required: ['triangles', 'materials', 'textures', 'meshes', 'bodies', 'entities'],
+  }
+
+  export const validate: ValidateFunction<Metrics> = generateValidator(schema)
+}
+
+

--- a/src/platform/wearables/metrics.ts
+++ b/src/platform/wearables/metrics.ts
@@ -1,5 +1,6 @@
 import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
 
+/** @alpha */
 export type Metrics = {
   triangles: number
   materials: number
@@ -9,6 +10,7 @@ export type Metrics = {
   entities: number
 }
 
+/** @alpha */
 export namespace Metrics {
   export const schema: JSONSchema<Metrics> = {
     type: 'object',

--- a/src/platform/wearables/representation.ts
+++ b/src/platform/wearables/representation.ts
@@ -1,0 +1,52 @@
+import { WearableCategory } from '../../dapps/wearable-category'
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+import { WearableBodyShape } from './wearable-body-shape'
+
+export type WearableRepresentation = {
+  bodyShapes: WearableBodyShape[],
+  mainFile: string,
+  contents: string[],
+  overrideHides: WearableCategory[],
+  overrideReplaces: WearableCategory[]
+}
+
+export namespace WearableRepresentation {
+  export const schema: JSONSchema<WearableRepresentation> = {
+    type: 'object',
+    properties: {
+      bodyShapes: {
+        type: 'array',
+        items: WearableBodyShape.schema,
+        minItems: 1,
+        uniqueItems: true
+      },
+      mainFile: {
+        type: 'string',
+        minLength: 1,
+      },
+      contents: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        minItems: 1,
+        uniqueItems: true
+      },
+      overrideHides: {
+        type: 'array',
+        items: WearableCategory.schema
+      },
+      overrideReplaces: {
+        type: 'array',
+        items: WearableCategory.schema
+      }
+    },
+    additionalProperties: false,
+    required: ['bodyShapes', 'mainFile', 'contents', 'overrideHides', 'overrideReplaces'],
+
+  }
+
+  export const validate: ValidateFunction<WearableRepresentation> = generateValidator(schema)
+}
+
+

--- a/src/platform/wearables/representation.ts
+++ b/src/platform/wearables/representation.ts
@@ -2,6 +2,7 @@ import { WearableCategory } from '../../dapps/wearable-category'
 import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
 import { WearableBodyShape } from './wearable-body-shape'
 
+/** @alpha */
 export type WearableRepresentation = {
   bodyShapes: WearableBodyShape[],
   mainFile: string,
@@ -10,6 +11,7 @@ export type WearableRepresentation = {
   overrideReplaces: WearableCategory[]
 }
 
+/** @alpha */
 export namespace WearableRepresentation {
   export const schema: JSONSchema<WearableRepresentation> = {
     type: 'object',

--- a/src/platform/wearables/wearable-body-shape.ts
+++ b/src/platform/wearables/wearable-body-shape.ts
@@ -1,0 +1,15 @@
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+
+export enum WearableBodyShape {
+  MALE = 'urn:decentraland:off-chain:base-avatars:BaseMale',
+  FEMALE = 'urn:decentraland:off-chain:base-avatars:BaseFemale',
+}
+
+export namespace WearableBodyShape {
+  export const schema: JSONSchema<WearableBodyShape> = {
+    type: 'string',
+    enum: Object.values(WearableBodyShape),
+  }
+
+  export const validate: ValidateFunction<WearableBodyShape> = generateValidator(schema)
+}

--- a/src/platform/wearables/wearable-body-shape.ts
+++ b/src/platform/wearables/wearable-body-shape.ts
@@ -1,10 +1,12 @@
 import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
 
+/** @alpha */
 export enum WearableBodyShape {
   MALE = 'urn:decentraland:off-chain:base-avatars:BaseMale',
   FEMALE = 'urn:decentraland:off-chain:base-avatars:BaseFemale',
 }
 
+/** @alpha */
 export namespace WearableBodyShape {
   export const schema: JSONSchema<WearableBodyShape> = {
     type: 'string',

--- a/src/platform/wearables/wearable.ts
+++ b/src/platform/wearables/wearable.ts
@@ -8,10 +8,10 @@ import { Metrics } from './metrics'
 /** @alpha */
 export type Wearable = {
   id: string
-  description: I18N[]
+  descriptions: I18N[]
   collectionAddress: string
   rarity: Rarity
-  name: I18N[],
+  names: I18N[],
   data: {
     replaces: WearableCategory[]
     hides: WearableCategory[]
@@ -32,7 +32,7 @@ export namespace Wearable {
       id: {
         type: 'string',
       },
-      description: {
+      descriptions: {
         type: 'array',
         items: I18N.schema,
         minItems: 1
@@ -41,7 +41,7 @@ export namespace Wearable {
         type: 'string',
       },
       rarity: Rarity.schema,
-      name: {
+      names: {
         type: 'array',
         items: I18N.schema,
         minItems: 1
@@ -88,10 +88,10 @@ export namespace Wearable {
     additionalProperties: false,
     required: [
       'id',
-      'description',
+      'descriptions',
       'collectionAddress',
       'rarity',
-      'name',
+      'names',
       'data',
       'thumbnail',
       'image',

--- a/src/platform/wearables/wearable.ts
+++ b/src/platform/wearables/wearable.ts
@@ -1,0 +1,94 @@
+import { generateValidator, JSONSchema, ValidateFunction } from '../../validation'
+import { Rarity } from '../../dapps/rarity'
+import { WearableCategory } from '../../dapps/wearable-category'
+import { I18N } from './i18n'
+import { WearableRepresentation } from './representation'
+import { Metrics } from './metrics'
+
+export type Wearable = {
+  id: string
+  description: string
+  collectionAddress: string
+  rarity: Rarity
+  i18n: I18N,
+  data: {
+    replaces: WearableCategory[]
+    hides: WearableCategory[]
+    tags: string[]
+    representations: WearableRepresentation[]
+    category: WearableCategory
+  }
+  thumbnail: string
+  image: string
+  metrics?: Metrics
+}
+
+export namespace Wearable {
+  export const schema: JSONSchema<Wearable> = {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string',
+      },
+      description: {
+        type: 'string',
+      },
+      collectionAddress: {
+        type: 'string',
+      },
+      rarity: Rarity.schema,
+      i18n: I18N.schema,
+      data: {
+        type: 'object',
+        properties: {
+          replaces: {
+            type: 'array',
+            items: WearableCategory.schema
+          },
+          hides: {
+            type: 'array',
+            items: WearableCategory.schema
+          },
+          tags: {
+            type: 'array',
+            items: {
+              type: 'string',
+              minLength: 1
+            }
+          },
+          representations: {
+            type: 'array',
+            items: WearableRepresentation.schema,
+            minItems: 1
+          },
+          category: WearableCategory.schema
+        },
+        additionalProperties: false,
+        required: ['replaces', 'hides', 'tags', 'representations', 'category']
+      },
+      thumbnail: {
+        type: 'string',
+      },
+      image: {
+        type: 'string',
+      },
+      metrics: {
+        ...Metrics.schema,
+        nullable: true
+      }
+    },
+    additionalProperties: false,
+    required: [
+      'id',
+      'description',
+      'collectionAddress',
+      'rarity',
+      'i18n',
+      'data',
+      'thumbnail',
+      'image',
+    ],
+  }
+
+  export const validate: ValidateFunction<Wearable> = generateValidator(schema)
+}

--- a/src/platform/wearables/wearable.ts
+++ b/src/platform/wearables/wearable.ts
@@ -98,5 +98,13 @@ export namespace Wearable {
     ],
   }
 
-  export const validate: ValidateFunction<Wearable> = generateValidator(schema)
+  const schemaValidator: ValidateFunction<Wearable> = generateValidator(schema);
+  export const validate: ValidateFunction<Wearable> = (wearable: any): wearable is Wearable =>
+    schemaValidator(wearable) &&
+    validateDuplicatedLocales(wearable.descriptions) &&
+    validateDuplicatedLocales(wearable.names);
+
+  // Returns true only if there are no entries with the same locale
+  const validateDuplicatedLocales = (i18ns: I18N[]) =>
+    i18ns.every(({ code }, index) => i18ns.findIndex((i18n) => i18n.code === code) === index);
 }

--- a/src/platform/wearables/wearable.ts
+++ b/src/platform/wearables/wearable.ts
@@ -5,6 +5,7 @@ import { I18N } from './i18n'
 import { WearableRepresentation } from './representation'
 import { Metrics } from './metrics'
 
+/** @alpha */
 export type Wearable = {
   id: string
   description: I18N[]
@@ -23,6 +24,7 @@ export type Wearable = {
   metrics?: Metrics
 }
 
+/** @alpha */
 export namespace Wearable {
   export const schema: JSONSchema<Wearable> = {
     type: 'object',

--- a/src/platform/wearables/wearable.ts
+++ b/src/platform/wearables/wearable.ts
@@ -7,10 +7,10 @@ import { Metrics } from './metrics'
 
 export type Wearable = {
   id: string
-  description: string
+  description: I18N[]
   collectionAddress: string
   rarity: Rarity
-  i18n: I18N,
+  name: I18N[],
   data: {
     replaces: WearableCategory[]
     hides: WearableCategory[]
@@ -31,13 +31,19 @@ export namespace Wearable {
         type: 'string',
       },
       description: {
-        type: 'string',
+        type: 'array',
+        items: I18N.schema,
+        minItems: 1
       },
       collectionAddress: {
         type: 'string',
       },
       rarity: Rarity.schema,
-      i18n: I18N.schema,
+      name: {
+        type: 'array',
+        items: I18N.schema,
+        minItems: 1
+      },
       data: {
         type: 'object',
         properties: {
@@ -83,7 +89,7 @@ export namespace Wearable {
       'description',
       'collectionAddress',
       'rarity',
-      'i18n',
+      'name',
       'data',
       'thumbnail',
       'image',

--- a/test/platform/wearables/i18n.spec.ts
+++ b/test/platform/wearables/i18n.spec.ts
@@ -1,0 +1,18 @@
+import expect from 'expect'
+import { I18N, Locale } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('I18N tests', () => {
+  const i18n: I18N = {
+    code: Locale.ES,
+    text: 'some text'
+  }
+
+  testTypeSignature(I18N, i18n)
+
+  it('static tests must pass', () => {
+    expect(I18N.validate(i18n)).toEqual(true)
+    expect(I18N.validate(null)).toEqual(false)
+    expect(I18N.validate({})).toEqual(false)
+  })
+})

--- a/test/platform/wearables/locale.spec.ts
+++ b/test/platform/wearables/locale.spec.ts
@@ -1,0 +1,15 @@
+import expect from 'expect'
+import { Locale } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('Locale tests', () => {
+  const locale: Locale = Locale.EN
+
+  testTypeSignature(Locale, locale)
+
+  it('static tests must pass', () => {
+    expect(Locale.validate(locale)).toEqual(true)
+    expect(Locale.validate(null)).toEqual(false)
+    expect(Locale.validate({})).toEqual(false)
+  })
+})

--- a/test/platform/wearables/metrics.spec.ts
+++ b/test/platform/wearables/metrics.spec.ts
@@ -1,0 +1,22 @@
+import expect from 'expect'
+import { Metrics } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('Metrics tests', () => {
+  const metrics: Metrics = {
+    triangles: 10,
+    materials: 20,
+    textures: 30,
+    meshes: 40,
+    bodies: 50,
+    entities: 60
+  }
+
+  testTypeSignature(Metrics, metrics)
+
+  it('static tests must pass', () => {
+    expect(Metrics.validate(metrics)).toEqual(true)
+    expect(Metrics.validate(null)).toEqual(false)
+    expect(Metrics.validate({})).toEqual(false)
+  })
+})

--- a/test/platform/wearables/representation.spec.ts
+++ b/test/platform/wearables/representation.spec.ts
@@ -1,0 +1,49 @@
+import expect from 'expect'
+import { WearableBodyShape, WearableRepresentation } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('Representation tests', () => {
+  const representation: WearableRepresentation = {
+    bodyShapes: [WearableBodyShape.FEMALE],
+    mainFile: 'file1',
+    contents: ['file1', 'file2'],
+    overrideHides: [],
+    overrideReplaces: []
+  }
+
+  testTypeSignature(WearableRepresentation, representation)
+
+  it('static tests must pass', () => {
+    expect(WearableRepresentation.validate(representation)).toEqual(true)
+    expect(WearableRepresentation.validate(null)).toEqual(false)
+    expect(WearableRepresentation.validate({})).toEqual(false)
+  })
+
+  it('representation without body shape fails', () => {
+    expect(WearableRepresentation.validate({
+      ...representation,
+      bodyShapes: []
+    })).toEqual(false)
+  })
+
+  it('representation with repeated body shapes fails', () => {
+    expect(WearableRepresentation.validate({
+      ...representation,
+      bodyShapes: [WearableBodyShape.FEMALE, WearableBodyShape.FEMALE]
+    })).toEqual(false)
+  })
+
+  it('representation without content fails', () => {
+    expect(WearableRepresentation.validate({
+      ...representation,
+      contents: []
+    })).toEqual(false)
+  })
+
+  it('representation with repeated content fails', () => {
+    expect(WearableRepresentation.validate({
+      ...representation,
+      contents: ['file1', 'file1']
+    })).toEqual(false)
+  })
+})

--- a/test/platform/wearables/wearable-body-shape.spec.ts
+++ b/test/platform/wearables/wearable-body-shape.spec.ts
@@ -1,0 +1,15 @@
+import expect from 'expect'
+import { WearableBodyShape } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('BodyShape tests', () => {
+  const bodyShape: WearableBodyShape = WearableBodyShape.FEMALE
+
+  testTypeSignature(WearableBodyShape, bodyShape)
+
+  it('static tests must pass', () => {
+    expect(WearableBodyShape.validate(bodyShape)).toEqual(true)
+    expect(WearableBodyShape.validate(null)).toEqual(false)
+    expect(WearableBodyShape.validate({})).toEqual(false)
+  })
+})

--- a/test/platform/wearables/wearable.spec.ts
+++ b/test/platform/wearables/wearable.spec.ts
@@ -1,0 +1,54 @@
+import expect from 'expect'
+import { Locale, Rarity, Wearable, WearableBodyShape, WearableCategory, WearableRepresentation } from '../../../src'
+import { testTypeSignature } from '../../test-utils'
+
+describe('Representation tests', () => {
+
+  const representation: WearableRepresentation = {
+    bodyShapes: [WearableBodyShape.FEMALE],
+    mainFile: 'file1',
+    contents: ['file1', 'file2'],
+    overrideHides: [],
+    overrideReplaces: []
+  }
+
+  const wearable: Wearable = {
+    id: 'some id',
+    description: 'some description',
+    collectionAddress: '0x...',
+    rarity: Rarity.LEGENDARY,
+    i18n: {
+      code: Locale.EN,
+      text: 'name'
+    },
+    data: {
+      replaces: [],
+      hides: [],
+      tags: ['tag1'],
+      representations: [representation],
+      category: WearableCategory.UPPER_BODY,
+    },
+    thumbnail: 'thumbnail.png',
+    image: 'image.png'
+  }
+
+
+  testTypeSignature(Wearable, wearable)
+
+  it('static tests must pass', () => {
+    expect(Wearable.validate(wearable)).toEqual(true)
+    expect(Wearable.validate(null)).toEqual(false)
+    expect(Wearable.validate({})).toEqual(false)
+  })
+
+  it('wearable without representation fails', () => {
+    expect(WearableRepresentation.validate({
+      ...wearable,
+      data: {
+        ...wearable.data,
+        representations: []
+      }
+    })).toEqual(false)
+  })
+
+})

--- a/test/platform/wearables/wearable.spec.ts
+++ b/test/platform/wearables/wearable.spec.ts
@@ -48,17 +48,17 @@ describe('Representation tests', () => {
     expect(Wearable.validate({})).toEqual(false)
   })
 
-  it('wearable two names with same locale fails', () => {
+  it('wearable with two names with same locale fails', () => {
     expect(Wearable.validate({
       ...wearable,
-      names: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
+      names: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'otro texto' }]
     })).toEqual(false)
   })
 
-  it('wearable two descriptions with same locale fails', () => {
+  it('wearable with two descriptions with same locale fails', () => {
     expect(Wearable.validate({
       ...wearable,
-      descriptions: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
+      descriptions: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'otro texto' }]
     })).toEqual(false)
   })
 

--- a/test/platform/wearables/wearable.spec.ts
+++ b/test/platform/wearables/wearable.spec.ts
@@ -14,13 +14,16 @@ describe('Representation tests', () => {
 
   const wearable: Wearable = {
     id: 'some id',
-    description: 'some description',
+    description: [{
+      code: Locale.EN,
+      text: 'some description'
+    }],
     collectionAddress: '0x...',
     rarity: Rarity.LEGENDARY,
-    i18n: {
+    name: [{
       code: Locale.EN,
       text: 'name'
-    },
+    }],
     data: {
       replaces: [],
       hides: [],
@@ -48,6 +51,20 @@ describe('Representation tests', () => {
         ...wearable.data,
         representations: []
       }
+    })).toEqual(false)
+  })
+
+  it('wearable without name fails', () => {
+    expect(WearableRepresentation.validate({
+      ...wearable,
+      name: []
+    })).toEqual(false)
+  })
+
+  it('wearable without description fails', () => {
+    expect(WearableRepresentation.validate({
+      ...wearable,
+      description: []
     })).toEqual(false)
   })
 

--- a/test/platform/wearables/wearable.spec.ts
+++ b/test/platform/wearables/wearable.spec.ts
@@ -49,21 +49,21 @@ describe('Representation tests', () => {
   })
 
   it('wearable two names with same locale fails', () => {
-    expect(WearableRepresentation.validate({
+    expect(Wearable.validate({
       ...wearable,
       names: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
     })).toEqual(false)
   })
 
   it('wearable two descriptions with same locale fails', () => {
-    expect(WearableRepresentation.validate({
+    expect(Wearable.validate({
       ...wearable,
       descriptions: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
     })).toEqual(false)
   })
 
   it('wearable without representation fails', () => {
-    expect(WearableRepresentation.validate({
+    expect(Wearable.validate({
       ...wearable,
       data: {
         ...wearable.data,
@@ -73,14 +73,14 @@ describe('Representation tests', () => {
   })
 
   it('wearable without name fails', () => {
-    expect(WearableRepresentation.validate({
+    expect(Wearable.validate({
       ...wearable,
       name: []
     })).toEqual(false)
   })
 
   it('wearable without description fails', () => {
-    expect(WearableRepresentation.validate({
+    expect(Wearable.validate({
       ...wearable,
       description: []
     })).toEqual(false)

--- a/test/platform/wearables/wearable.spec.ts
+++ b/test/platform/wearables/wearable.spec.ts
@@ -14,13 +14,17 @@ describe('Representation tests', () => {
 
   const wearable: Wearable = {
     id: 'some id',
-    description: [{
+    descriptions: [{
       code: Locale.EN,
       text: 'some description'
+    },
+    {
+      code: Locale.ES,
+      text: 'una descripcion'
     }],
     collectionAddress: '0x...',
     rarity: Rarity.LEGENDARY,
-    name: [{
+    names: [{
       code: Locale.EN,
       text: 'name'
     }],
@@ -42,6 +46,20 @@ describe('Representation tests', () => {
     expect(Wearable.validate(wearable)).toEqual(true)
     expect(Wearable.validate(null)).toEqual(false)
     expect(Wearable.validate({})).toEqual(false)
+  })
+
+  it('wearable two names with same locale fails', () => {
+    expect(WearableRepresentation.validate({
+      ...wearable,
+      names: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
+    })).toEqual(false)
+  })
+
+  it('wearable two descriptions with same locale fails', () => {
+    expect(WearableRepresentation.validate({
+      ...wearable,
+      descriptions: [{ code: Locale.ES, text: 'texto' }, { code: Locale.ES, text: 'texto' }]
+    })).toEqual(false)
   })
 
   it('wearable without representation fails', () => {


### PR DESCRIPTION
We are now adding a schema in order to validate wearables that will be stored on the content server.

We are making some breaking changes to the current wearables:
* Renamed property `i18n` to `names`
* The type for `description` went from `string` to `I18N[]`
* Renamed property `description` to `descriptions`
* Removed properties `createdAt` & `updatedAt`