### PR TITLE
fix: add extra validation to wearables representation

### DIFF
--- a/src/platform/wearables/representation.ts
+++ b/src/platform/wearables/representation.ts
@@ -48,7 +48,7 @@ export namespace WearableRepresentation {
 
   }
 
-  export const schemaValidator: ValidateFunction<WearableRepresentation> = generateValidator(schema)
+  const schemaValidator: ValidateFunction<WearableRepresentation> = generateValidator(schema)
   export const validate: ValidateFunction<WearableRepresentation> = (representation: any): representation is WearableRepresentation =>
     schemaValidator(representation) &&
     representation.contents.includes(representation.mainFile)

--- a/src/platform/wearables/representation.ts
+++ b/src/platform/wearables/representation.ts
@@ -48,7 +48,11 @@ export namespace WearableRepresentation {
 
   }
 
-  export const validate: ValidateFunction<WearableRepresentation> = generateValidator(schema)
+  export const schemaValidator: ValidateFunction<WearableRepresentation> = generateValidator(schema)
+  export const validate: ValidateFunction<WearableRepresentation> = (representation: any): representation is WearableRepresentation =>
+    schemaValidator(representation) &&
+    representation.contents.includes(representation.mainFile)
+
 }
 
 

--- a/test/platform/wearables/representation.spec.ts
+++ b/test/platform/wearables/representation.spec.ts
@@ -46,4 +46,12 @@ describe('Representation tests', () => {
       contents: ['file1', 'file1']
     })).toEqual(false)
   })
+
+  it('main file not in contents fails', () => {
+    expect(WearableRepresentation.validate({
+      ...representation,
+      mainFile: ['file1'],
+      contents: ['file2', 'file3']
+    })).toEqual(false)
+  })
 })


### PR DESCRIPTION
We are now making sure that `mainFile` is one of the files in `contents`