### PR TITLE
feat: added isOnSale to item

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -192,6 +192,7 @@ export type Item = {
     rarity: Rarity;
     price: string;
     available: number;
+    isOnSale: boolean;
     creator: string;
     createdAt: number;
     updatedAt: number;
@@ -672,8 +673,8 @@ export namespace World {
 // src/dapps/bid.ts:21:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/contract.ts:10:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/contract.ts:11:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/item.ts:24:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/item.ts:25:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
+// src/dapps/item.ts:25:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/item.ts:26:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/nft.ts:46:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/nft.ts:47:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/order.ts:17:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/item.ts
+++ b/src/dapps/item.ts
@@ -17,6 +17,7 @@ export type Item = {
   rarity: Rarity
   price: string
   available: number
+  isOnSale: boolean
   creator: string
   createdAt: number
   updatedAt: number
@@ -57,6 +58,9 @@ export namespace Item {
       available: {
         type: 'integer',
       },
+      isOnSale: {
+        type: 'boolean',
+      },
       creator: {
         type: 'string',
       },
@@ -81,6 +85,7 @@ export namespace Item {
       'rarity',
       'price',
       'available',
+      'isOnSale',
       'creator',
       'data',
       'network',

--- a/test/item.spec.ts
+++ b/test/item.spec.ts
@@ -25,6 +25,7 @@ describe('Item tests', () => {
       rarity: Rarity.MYTHIC,
       price: '808000000000000000000',
       available: 0,
+      isOnSale: false,
       creator: '0xfe705ead02e849e78278c50de3d939be23448f1a',
       data: {
         wearable: {


### PR DESCRIPTION
The `isOnSale`  boolean tells if an item is available for purchase (this means the `Store` contract has been added as minter, and the max supply has not been reached yet).

Without this piece of information, from the frontend we can't know if we should allow the user to purchase the item or not.