### PR TITLE
fix: be explicit when referring to mainnet

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -98,7 +98,7 @@ export enum ChainName {
     // (undocumented)
     ETHEREUM_KOVAN = "Kovan",
     // (undocumented)
-    ETHEREUM_MAINNET = "Ethereum",
+    ETHEREUM_MAINNET = "Ethereum Mainnet",
     // (undocumented)
     ETHEREUM_RINKEBY = "Rinkeby",
     // (undocumented)

--- a/src/dapps/chain-name.ts
+++ b/src/dapps/chain-name.ts
@@ -6,7 +6,7 @@ import { ChainId } from './chain-id'
  * @alpha
  */
 export enum ChainName {
-  ETHEREUM_MAINNET = 'Ethereum',
+  ETHEREUM_MAINNET = 'Ethereum Mainnet',
   ETHEREUM_ROPSTEN = 'Ropsten',
   ETHEREUM_RINKEBY = 'Rinkeby',
   ETHEREUM_GOERLI = 'Goerli',


### PR DESCRIPTION
So this: 
![image](https://user-images.githubusercontent.com/692077/131729584-eb017333-bd61-41a2-bf5b-8f652e7d2193.png)

looks like this:

![image](https://user-images.githubusercontent.com/692077/131729693-c180781d-4368-452f-ac3a-1de2caf61a67.png)
