### PR TITLE
fix: string pattern for IPFS CIDv1 hashes

### DIFF
--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -74,7 +74,7 @@ export type IPFSv2 = string
 export namespace IPFSv2 {
   export const schema: JSONSchema<IPFSv2> = {
     type: 'string',
-    pattern: '^(bafy)[a-zA-Z0-9]{55}$'
+    pattern: '^(ba)[a-zA-Z0-9]{57}$'
   }
   const schemaValidator: ValidateFunction<IPFSv2> = generateValidator(schema);
   export const validate: ValidateFunction<IPFSv2> = (hash: any): hash is IPFSv2 =>


### PR DESCRIPTION
Current `bafy` starting validation is not accurate since `bafkreigwey5vc6q25ilofdu2vjvcag72eqj46lzipi6mredsfpe42ls2ri` is a valid hash.

According to the specs, `b` corresponds to base32 and `a` to CID version (varint).