### PR TITLE
feat: Add beneficiary to Item

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -462,6 +462,7 @@ export type Item = {
     available: number;
     isOnSale: boolean;
     creator: string;
+    beneficiary: string | null;
     createdAt: number;
     updatedAt: number;
     reviewedAt: number;
@@ -1368,9 +1369,9 @@ export namespace World {
 // src/dapps/contract.ts:10:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/contract.ts:11:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/contract.ts:16:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/item.ts:28:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/item.ts:29:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/item.ts:48:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/item.ts:29:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/item.ts:30:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
+// src/dapps/item.ts:49:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/mint.ts:16:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/mint.ts:17:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/mint.ts:37:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/item.ts
+++ b/src/dapps/item.ts
@@ -20,6 +20,7 @@ export type Item = {
   available: number
   isOnSale: boolean
   creator: string
+  beneficiary: string | null
   createdAt: number
   updatedAt: number
   reviewedAt: number
@@ -93,6 +94,10 @@ export namespace Item {
       },
       creator: {
         type: 'string'
+      },
+      beneficiary: {
+        type: 'string',
+        nullable: true
       },
       data: NFT.schema.properties!.data,
       network: Network.schema,

--- a/test/item.spec.ts
+++ b/test/item.spec.ts
@@ -26,6 +26,7 @@ describe('Item tests', () => {
       available: 0,
       isOnSale: false,
       creator: '0xfe705ead02e849e78278c50de3d939be23448f1a',
+      beneficiary: '0xfe705ead02e849e78278c50de3d939be23448f1a',
       data: {
         wearable: {
           description: 'Wearable by DaddyChang',


### PR DESCRIPTION
## Description

While moving some of the builder functionality to the marketplace, we realized we need the `beneficiary` as part of what the `nft-server` returns to the client. 