### PR TITLE
fix: misc validation

### DIFF
--- a/src/dapps/account.ts
+++ b/src/dapps/account.ts
@@ -1,5 +1,5 @@
-import { Network } from '..'
 import { generateValidator, JSONSchema, ValidateFunction } from '../validation'
+import { Network } from './network'
 
 export type Account = {
   id: string

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,4 +1,4 @@
-import { generateValidator, JSONSchema, ValidateFunction } from '..'
+import { generateValidator, JSONSchema, ValidateFunction } from "../validation";
 
 /**
  * Color3 is a data type that describes a color using R, G and B components

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -57,11 +57,10 @@ export namespace EthAddress {
     type: 'string',
     pattern: '^0x[a-fA-F0-9]{40}$'
   }
-  const schemaValidator: ValidateFunction<EthAddress> =
-    generateValidator(schema)
+  const regexp = new RegExp(schema.pattern!)
   export const validate: ValidateFunction<EthAddress> = (
     ethAddress: any
-  ): ethAddress is EthAddress => schemaValidator(ethAddress)
+  ): ethAddress is EthAddress => regexp.test(ethAddress)
 }
 
 /**
@@ -79,10 +78,10 @@ export namespace IPFSv2 {
     type: 'string',
     pattern: '^(ba)[a-zA-Z0-9]{57}$'
   }
-  const schemaValidator: ValidateFunction<IPFSv2> = generateValidator(schema)
+  const regexp = new RegExp(schema.pattern!)
   export const validate: ValidateFunction<IPFSv2> = (
     hash: any
-  ): hash is IPFSv2 => schemaValidator(hash)
+  ): hash is IPFSv2 => regexp.test(hash)
 }
 
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,4 +1,4 @@
-import { generateValidator, JSONSchema, ValidateFunction } from "../validation";
+import { generateValidator, JSONSchema, ValidateFunction } from '../validation'
 
 /**
  * Color3 is a data type that describes a color using R, G and B components

--- a/test/misc/index.spec.ts
+++ b/test/misc/index.spec.ts
@@ -3,17 +3,39 @@ import { EthAddress, IPFSv2, Color3 } from '../../src/misc'
 
 describe('Misc tests', () => {
   it('EthAddress static tests must pass', () => {
-    expect(EthAddress.validate('0x00000000000000000000000000000000000000000')).toEqual(false)
-    expect(EthAddress.validate('0x0000000000000000000000000000000000000000')).toEqual(true)
-    expect(EthAddress.validate('0x000000000000000000000000000000000000000')).toEqual(false)
+    expect(
+      EthAddress.validate('0x00000000000000000000000000000000000000000')
+    ).toEqual(false)
+    expect(
+      EthAddress.validate('0x0000000000000000000000000000000000000000')
+    ).toEqual(true)
+    expect(
+      EthAddress.validate('0x000000000000000000000000000000000000000')
+    ).toEqual(false)
     expect(EthAddress.validate(null)).toEqual(false)
     expect(EthAddress.validate({})).toEqual(false)
   })
   it('IPFSv2 static tests must pass', () => {
-    expect(IPFSv2.validate('ba0000000000000000000000000000000000000000000000000000000000')).toEqual(false)
-    expect(IPFSv2.validate('ba000000000000000000000000000000000000000000000000000000000')).toEqual(true)
-    expect(IPFSv2.validate('00000000000000000000000000000000000000000000000000000000000')).toEqual(false)
-    expect(IPFSv2.validate('ab00000000000000000000000000000000000000000000000000000000')).toEqual(false)
+    expect(
+      IPFSv2.validate(
+        'ba0000000000000000000000000000000000000000000000000000000000'
+      )
+    ).toEqual(false)
+    expect(
+      IPFSv2.validate(
+        'ba000000000000000000000000000000000000000000000000000000000'
+      )
+    ).toEqual(true)
+    expect(
+      IPFSv2.validate(
+        '00000000000000000000000000000000000000000000000000000000000'
+      )
+    ).toEqual(false)
+    expect(
+      IPFSv2.validate(
+        'ab00000000000000000000000000000000000000000000000000000000'
+      )
+    ).toEqual(false)
     expect(IPFSv2.validate(null)).toEqual(false)
     expect(IPFSv2.validate({})).toEqual(false)
   })

--- a/test/misc/index.spec.ts
+++ b/test/misc/index.spec.ts
@@ -1,0 +1,29 @@
+import expect from 'expect'
+import { EthAddress, IPFSv2, Color3 } from '../../src/misc'
+
+describe('Misc tests', () => {
+  it('EthAddress static tests must pass', () => {
+    expect(EthAddress.validate('0x00000000000000000000000000000000000000000')).toEqual(false)
+    expect(EthAddress.validate('0x0000000000000000000000000000000000000000')).toEqual(true)
+    expect(EthAddress.validate('0x000000000000000000000000000000000000000')).toEqual(false)
+    expect(EthAddress.validate(null)).toEqual(false)
+    expect(EthAddress.validate({})).toEqual(false)
+  })
+  it('IPFSv2 static tests must pass', () => {
+    expect(IPFSv2.validate('ba0000000000000000000000000000000000000000000000000000000000')).toEqual(false)
+    expect(IPFSv2.validate('ba000000000000000000000000000000000000000000000000000000000')).toEqual(true)
+    expect(IPFSv2.validate('00000000000000000000000000000000000000000000000000000000000')).toEqual(false)
+    expect(IPFSv2.validate('ab00000000000000000000000000000000000000000000000000000000')).toEqual(false)
+    expect(IPFSv2.validate(null)).toEqual(false)
+    expect(IPFSv2.validate({})).toEqual(false)
+  })
+  it('Color3 static tests must pass', () => {
+    expect(Color3.validate('rgb(255,255,255)')).toEqual(false)
+    expect(Color3.validate(null)).toEqual(false)
+    expect(Color3.validate({})).toEqual(false)
+    expect(Color3.validate({ r: -1, g: -1, b: -1 })).toEqual(false)
+    expect(Color3.validate({ r: 0, g: 0, b: 0 })).toEqual(true)
+    expect(Color3.validate({ r: 1, g: 1, b: 1 })).toEqual(true)
+    expect(Color3.validate({ r: 2, g: 2, b: 2 })).toEqual(false)
+  })
+})


### PR DESCRIPTION
## What happen

Users with a older browser versions are getting the following error: https://rollbar.com/decentraland/events/items/776/

```
Invalid flags supplied to RegExp constructor 'u'
```

because the version of ajv used injects the flag `u` when it gets a pattern attribute:

<img width="490" alt="Screen Shot 2022-04-20 at 17 51 21" src="https://user-images.githubusercontent.com/208789/164320640-d20013ae-710d-475e-a43d-2de5a8363065.png">

## Changes

- removes imports from main
- add test for misc
- refactor tu avoid `generateValidator` on patterns