### PR TITLE
feat: added more preview types

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -930,6 +930,7 @@ export type PreviewConfig = {
     emote: PreviewEmote;
     camera: PreviewCamera;
     autoRotateSpeed: number;
+    centerBoundingBox: boolean;
     offsetX: number;
     offsetY: number;
     offsetZ: number;
@@ -954,6 +955,10 @@ export enum PreviewEmote {
     FASHION_3 = "fashion-3",
     // (undocumented)
     FASHION_4 = "fashion-4",
+    // (undocumented)
+    FIST_PUMP = "fist-pump",
+    // (undocumented)
+    HEAD_EXPLODE = "head-explode",
     // (undocumented)
     IDLE = "idle",
     // (undocumented)
@@ -1005,6 +1010,8 @@ export enum PreviewMessageType {
     // (undocumented)
     LOAD = "load",
     // (undocumented)
+    READY = "ready",
+    // (undocumented)
     UPDATE = "update"
 }
 
@@ -1033,6 +1040,7 @@ export type PreviewOptions = {
     emote?: PreviewEmote | null;
     camera?: PreviewCamera | null;
     autoRotateSpeed?: number | null;
+    centerBoundingBox?: boolean | null;
     offsetX?: number | null;
     offsetY?: number | null;
     offsetZ?: number | null;
@@ -1647,7 +1655,7 @@ export namespace World {
 // src/dapps/preview/preview-config.ts:9:3 - (ae-incompatible-release-tags) The symbol "wearables" is marked as @public, but its signature references "WearableDefinition" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:10:3 - (ae-incompatible-release-tags) The symbol "bodyShape" is marked as @public, but its signature references "WearableBodyShape" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:15:3 - (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "PreviewType" which is marked as @alpha
-// src/dapps/preview/preview-message.ts:31:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:32:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
 // src/dapps/sale.ts:18:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/sale.ts:19:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/sale.ts:42:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/preview/preview-config.ts
+++ b/src/dapps/preview/preview-config.ts
@@ -20,6 +20,7 @@ export type PreviewConfig = {
   emote: PreviewEmote
   camera: PreviewCamera
   autoRotateSpeed: number
+  centerBoundingBox: boolean
   offsetX: number
   offsetY: number
   offsetZ: number

--- a/src/dapps/preview/preview-emote.ts
+++ b/src/dapps/preview/preview-emote.ts
@@ -14,7 +14,9 @@ export enum PreviewEmote {
   FASHION_3 = 'fashion-3',
   FASHION_4 = 'fashion-4',
   LOVE = 'love',
-  MONEY = 'money'
+  MONEY = 'money',
+  FIST_PUMP = 'fist-pump',
+  HEAD_EXPLODE = 'head-explode'
 }
 
 /** @alpha */

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -6,6 +6,7 @@ import {
 import { PreviewOptions } from './preview-options'
 
 export enum PreviewMessageType {
+  READY = 'ready',
   LOAD = 'load',
   ERROR = 'error',
   UPDATE = 'update'

--- a/src/dapps/preview/preview-options.ts
+++ b/src/dapps/preview/preview-options.ts
@@ -20,6 +20,7 @@ export type PreviewOptions = {
   emote?: PreviewEmote | null
   camera?: PreviewCamera | null
   autoRotateSpeed?: number | null
+  centerBoundingBox?: boolean | null
   offsetX?: number | null
   offsetY?: number | null
   offsetZ?: number | null


### PR DESCRIPTION
**Added more preview types**
- Two more default emotes: `head-explode` and `fist-pump` (as requested by curators)
- Added options to disable the centering of the bounding box (as requested by Decentral Games team)
- Added `ready` message, which will be used to solve this issue: https://github.com/decentraland/wearable-preview/issues/27