### PR TITLE
fix: using combiation of numbers and ranges for spawnpoints

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1372,7 +1372,7 @@ export namespace Source {
 // @alpha (undocumented)
 export type SpawnPoint = {
     name?: string;
-    position: SinglePosition | MultiPosition;
+    position: MultiPosition;
     default?: boolean;
     cameraTarget?: SinglePosition;
 };
@@ -1659,8 +1659,8 @@ export namespace World {
 // src/dapps/sale.ts:18:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/sale.ts:19:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/sale.ts:42:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/platform/scene/spawn-point.ts:10:3 - (ae-forgotten-export) The symbol "SinglePosition" needs to be exported by the entry point index.d.ts
 // src/platform/scene/spawn-point.ts:10:3 - (ae-forgotten-export) The symbol "MultiPosition" needs to be exported by the entry point index.d.ts
+// src/platform/scene/spawn-point.ts:12:3 - (ae-forgotten-export) The symbol "SinglePosition" needs to be exported by the entry point index.d.ts
 // src/sdk/project/asset-json.ts:24:3 - (ae-forgotten-export) The symbol "AssetWearableGender" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/src/platform/scene/spawn-point.ts
+++ b/src/platform/scene/spawn-point.ts
@@ -7,7 +7,7 @@ import {
 /** @alpha */
 export type SpawnPoint = {
   name?: string
-  position: SinglePosition | MultiPosition
+  position: MultiPosition
   default?: boolean
   cameraTarget?: SinglePosition
 }
@@ -18,9 +18,9 @@ type SinglePosition = {
   z: number
 }
 type MultiPosition = {
-  x: number[]
-  y: number[]
-  z: number[]
+  x: number | number[]
+  y: number | number[]
+  z: number | number[]
 }
 
 /** @alpha */


### PR DESCRIPTION
[Τhe kernel type for scene spawnpoints is a combination of numbers and ranges](https://github.com/decentraland/kernel/blob/cb7b6ee26944c821f1af16efb64c81444f0feded/kernel/packages/shared/types.ts#L282) while the validator currently only supports having one of those variants for each spawnpoint.

This PR changes the type to allow combinations of types in the validator.