### PR TITLE
feat(preview): added wheel related types

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -934,6 +934,9 @@ export type PreviewConfig = {
     offsetX: number;
     offsetY: number;
     offsetZ: number;
+    wheelZoom: number;
+    wheelPrecision: number;
+    wheelStart: number;
 };
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
@@ -1044,6 +1047,9 @@ export type PreviewOptions = {
     offsetX?: number | null;
     offsetY?: number | null;
     offsetZ?: number | null;
+    wheelZoom?: number | null;
+    wheelPrecision?: number | null;
+    wheelStart?: number | null;
     transparentBackground?: boolean;
     env?: PreviewEnv | null;
 };

--- a/src/dapps/preview/preview-config.ts
+++ b/src/dapps/preview/preview-config.ts
@@ -24,4 +24,7 @@ export type PreviewConfig = {
   offsetX: number
   offsetY: number
   offsetZ: number
+  wheelZoom: number
+  wheelPrecision: number
+  wheelStart: number
 }

--- a/src/dapps/preview/preview-options.ts
+++ b/src/dapps/preview/preview-options.ts
@@ -24,6 +24,9 @@ export type PreviewOptions = {
   offsetX?: number | null
   offsetY?: number | null
   offsetZ?: number | null
+  wheelZoom?: number | null
+  wheelPrecision?: number | null
+  wheelStart?: number | null
   transparentBackground?: boolean
   env?: PreviewEnv | null
 }


### PR DESCRIPTION
Added mouse wheel related types for options/config

- `wheelZoom`: a multiplier of how much you can zoom with the wheel. A value of `1` means wheel does nothing, a value of `2` means you can zoom up to 2x with the wheel.
- `wheelPrecision`: the higher value the slower the wheel zooms.
- `wheelStart`: a value between 0 and 100. If set to 50 the wheel zoom will start in the middle and you will be able to zoom in or out. If 0 you will start zoomed out and only able to zoom in, and so on and so forth.