### PR TITLE
feat: Add AnalyticsDayData to track marketplace operations volume

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -69,6 +69,36 @@ type Actions = typeof SCENE_UPDATE | typeof UPDATE;
 
 export { Ajv }
 
+// Warning: (ae-missing-release-tag) "AnalyticsDayData" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AnalyticsDayData = {
+    id: string;
+    date: number;
+    sales: number;
+    volume: string;
+    creatorsEarnings: string;
+    daoEarnings: string;
+};
+
+// Warning: (ae-missing-release-tag) "AnalyticsDayDataFilters" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AnalyticsDayDataFilters = {
+    from?: number;
+    network?: Network;
+};
+
+// Warning: (ae-missing-release-tag) "AnalyticsDayDataSortBy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum AnalyticsDayDataSortBy {
+    // (undocumented)
+    DATE = "date",
+    // (undocumented)
+    MOST_SALES = "most_sales"
+}
+
 // @alpha (undocumented)
 type AssetJson = {
     id: string;
@@ -1691,6 +1721,7 @@ export namespace World {
 // Warnings were encountered during analysis:
 //
 // src/dapps/account.ts:28:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/analyticsDayData.ts:14:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/bid.ts:21:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/bid.ts:22:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/bid.ts:41:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/analyticsDayData.ts
+++ b/src/dapps/analyticsDayData.ts
@@ -1,0 +1,20 @@
+import { Network } from './network'
+
+export type AnalyticsDayData = {
+  id: string
+  date: number
+  sales: number
+  volume: string
+  creatorsEarnings: string
+  daoEarnings: string
+}
+
+export type AnalyticsDayDataFilters = {
+  from?: number
+  network?: Network
+}
+
+export enum AnalyticsDayDataSortBy {
+  DATE = 'date',
+  MOST_SALES = 'most_sales'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ export { ProviderType } from './dapps/provider-type'
 export { Rarity } from './dapps/rarity'
 export { SaleType } from './dapps/sale-type'
 export { Sale, SaleFilters, SaleSortBy } from './dapps/sale'
+export {
+  AnalyticsDayData,
+  AnalyticsDayDataFilters,
+  AnalyticsDayDataSortBy
+} from './dapps/analyticsDayData'
 export { Store } from './dapps/store'
 export { WearableCategory } from './dapps/wearable-category'
 export { WearableGender } from './dapps/wearable-gender'


### PR DESCRIPTION
## What 

`VolumeData` will track the operations done using the Marketplace dApp such as orders and bids for LAND, Estates, Names / NFT Mints and secondary sales. It will also track the DAO earnings. 