### PR TITLE
fix: Remove push push on tags CI action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    tags:
-      - '*'
     branches:
       - master
       - main


### PR DESCRIPTION
This PR removes the behavior where pushing a tag on master published the package. The publishing process after a tag push should be done by doing a release.