### PR TITLE
feat: Add "categories" attribute to the SaleFilters type

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1403,7 +1403,7 @@ export type SaleFilters = {
     skip?: number;
     sortBy?: SaleSortBy;
     type?: SaleType;
-    category?: NFTCategory;
+    categories?: NFTCategory[];
     buyer?: string;
     seller?: string;
     contractAddress?: string;

--- a/src/dapps/sale.ts
+++ b/src/dapps/sale.ts
@@ -29,7 +29,7 @@ export type SaleFilters = {
   skip?: number
   sortBy?: SaleSortBy
   type?: SaleType
-  category?: NFTCategory
+  categories?: NFTCategory[]
   buyer?: string
   seller?: string
   contractAddress?: string


### PR DESCRIPTION
Why? 

We want to support passing by multiple categories when asking for sales. In this case, we need to ask for `parcel`s and `estate`s  so the filters type should expect an array.