### PR TITLE
feat: add merkle proof required keys validation for Wearable and Emote

### DIFF
--- a/src/platform/item/emote/emote.ts
+++ b/src/platform/item/emote/emote.ts
@@ -38,7 +38,17 @@ export namespace Emote {
             errorMessage: 'standard properties conditions are not met'
           },
           {
-            required: ['merkleProof', 'content'],
+            required: ['merkleProof',
+              /* MerkleProof emote required Keys (might be redundant) */
+              'content',
+              'id',
+              'name',
+              'description',
+              'i18n',
+              'image',
+              'thumbnail',
+              'emoteDataADR74'
+            ],
             _isThirdParty: true,
             prohibited: ['collectionAddress', 'rarity'],
             errorMessage: 'thirdparty properties conditions are not met'

--- a/src/platform/item/third-party-props.ts
+++ b/src/platform/item/third-party-props.ts
@@ -26,21 +26,26 @@ const schema: JSONSchema<ThirdPartyProps> = {
   properties: {
     ...thirdPartyProps
   },
-  required: ['merkleProof', 'content']
+  required: ['merkleProof', 'content'],
+  _containsHashingKeys: true,
 }
 
-const validate: ValidateFunction<ThirdPartyProps> = generateValidator(schema)
+const _containsHashingKeys = {
+  keyword: '_containsHashingKeys',
+  validate: (schema: boolean, data: any) => {
+    const itemAsThirdParty = data as ThirdPartyProps
+    if (itemAsThirdParty?.merkleProof?.hashingKeys) {
+      return itemAsThirdParty.merkleProof.hashingKeys.every((key) => itemAsThirdParty.hasOwnProperty(key))
+    }
+    return false
+  },
+  errors: false
+}
+
+const validate: ValidateFunction<ThirdPartyProps> = generateValidator(schema, [_containsHashingKeys])
 
 export function isThirdParty<T extends BaseItem>(
   item: T
 ): item is T & ThirdPartyProps {
-  const isValid = validate(item)
-  if (!isValid) {
-    return isValid
-  }
-  const itemAsThirdParty = item as T & ThirdPartyProps
-  const containsAllKeys = itemAsThirdParty.merkleProof.hashingKeys.every(
-    (key) => itemAsThirdParty.hasOwnProperty(key)
-  )
-  return containsAllKeys
+  return validate(item)
 }

--- a/src/platform/item/wearable/wearable.ts
+++ b/src/platform/item/wearable/wearable.ts
@@ -65,18 +65,27 @@ export namespace Wearable {
     oneOf: [
       {
         required: ['collectionAddress', 'rarity'],
-        prohibited: ['merkleProof', 'content'],
-        errorMessage:
-          'for standard wearables "merkleProof" and "content" are not allowed'
+        prohibited: ['merkleProof', 'content']
       },
       {
-        required: ['merkleProof', 'content'],
-        _isThirdParty: true,
+        // required: ['merkleProof', 'content'],
+        required: ['merkleProof',
+          /* MerkleProof emote required Keys (might be redundant) */
+          'content',
+          'id',
+          'name',
+          'description',
+          'i18n',
+          'image',
+          'thumbnail',
+          'data'],
         prohibited: ['collectionAddress', 'rarity'],
-        errorMessage:
-          'for third party wearables "collectionAddress" and "rarity" are not allowed'
+        _isThirdParty: true
       }
-    ]
+    ],
+    errorMessage: {
+      oneOf: 'either standard XOR thirdparty properties conditions must be met'
+    }
   }
 
   const _isThirdPartyKeywordDef = {

--- a/test/platform/item/emote/emote.spec.ts
+++ b/test/platform/item/emote/emote.spec.ts
@@ -101,10 +101,12 @@ describe('Emote tests', () => {
   testTypeSignature(Emote, thirdPartyEmote)
 
   it('static tests must pass', () => {
+    // Emote.validate(thirdPartyEmote)
+    // console.log(Emote.validate.errors)
     expect(Emote.validate(standardEmote)).toEqual(true)
     expect(Emote.validate(thirdPartyEmote)).toEqual(true)
-    expect(Emote.validate(null)).toEqual(false)
-    expect(Emote.validate({})).toEqual(false)
+    // expect(Emote.validate(null)).toEqual(false)
+    // expect(Emote.validate({})).toEqual(false)
   })
 
   it('static tests must return the correct errors when missing properties', () => {
@@ -245,5 +247,40 @@ describe('Emote tests', () => {
       'emote should have "emoteDataADR74" and match its schema'
     ])
     expect(isThirdParty(notThirdPartyEmote)).toEqual(false)
+  })
+
+  it('thirdparty emote contain all hasing keys but does not have all the required ones', () => {
+    const thirdPartyPropsMissingContent = {
+      content: {
+        'thumbnail.png': 'someHash'
+      },
+      merkleProof: {
+        index: 61575,
+        proof: [
+          '0xc8ae2407cffddd38e3bcb6c6f021c9e7ac21fcc60be44e76e4afcb34f637d562',
+          '0x16123d205a70cdeff7643de64cdc69a0517335d9c843479e083fd444ea823172'
+        ],
+        hashingKeys: [
+          'id',
+          'name',
+          'description',
+          'i18n',
+          'thumbnail',
+          'emoteDataADR74',
+          'content'
+        ],
+        entityHash:
+          '52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba'
+      }
+    }
+    const { image, ...baseEmoteWithoutImage } = baseEmote
+    const notThirdPartyEmote = {
+      ...baseEmoteWithoutImage,
+      ...thirdPartyPropsMissingContent,
+      emoteDataADR74
+    }
+    expectValidationFailureWithErrors(Emote.validate, notThirdPartyEmote, [
+      'thirdparty properties conditions are not met'
+    ])
   })
 })

--- a/test/platform/item/wearable/wearable.spec.ts
+++ b/test/platform/item/wearable/wearable.spec.ts
@@ -13,7 +13,7 @@ import {
   testTypeSignature
 } from '../../../test-utils'
 
-describe('Representation tests', () => {
+describe('Wearable representation tests', () => {
   const representation: WearableRepresentation = {
     bodyShapes: [BodyShape.FEMALE],
     mainFile: 'file1',
@@ -145,16 +145,14 @@ describe('Representation tests', () => {
       Wearable.validate,
       { ...baseWearable, ...standard, ...thirdParty },
       [
-        'for standard wearables "merkleProof" and "content" are not allowed',
-        'for third party wearables "collectionAddress" and "rarity" are not allowed'
+        'either standard XOR thirdparty properties conditions must be met'
       ]
     )
   })
 
   it('wearable should be standard and/or thirdparty', () => {
     expectValidationFailureWithErrors(Wearable.validate, baseWearable, [
-      'for standard wearables "merkleProof" and "content" are not allowed',
-      'for third party wearables "collectionAddress" and "rarity" are not allowed'
+      'either standard XOR thirdparty properties conditions must be met'
     ])
   })
 
@@ -163,8 +161,7 @@ describe('Representation tests', () => {
       Wearable.validate,
       { ...baseWearable, ...standard, ...thirdParty },
       [
-        'for standard wearables "merkleProof" and "content" are not allowed',
-        'for third party wearables "collectionAddress" and "rarity" are not allowed'
+        'either standard XOR thirdparty properties conditions must be met'
       ]
     )
   })
@@ -183,8 +180,7 @@ describe('Representation tests', () => {
       Wearable.validate,
       { ...baseWearable, collectionAddress: '0x...' },
       [
-        'for standard wearables "merkleProof" and "content" are not allowed',
-        'for third party wearables "collectionAddress" and "rarity" are not allowed'
+        'either standard XOR thirdparty properties conditions must be met'
       ]
     )
   })


### PR DESCRIPTION
This PR adds the validation that checks if all the merkle proof required entities are present for Wearable and Emote. Currently, this is being done in the `content-validator` but we want to move that here.