### PR TITLE
chore: remove LOOP category and add boolean field 'loop' to EmoteData

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -497,8 +497,6 @@ export namespace Emote {
 // @public (undocumented)
 export enum EmoteCategory {
     // (undocumented)
-    LOOP = "loop",
-    // (undocumented)
     SIMPLE = "simple"
 }
 
@@ -518,6 +516,7 @@ export type EmoteDataADR74 = {
     category: EmoteCategory;
     representations: EmoteRepresentationADR74[];
     tags: string[];
+    loop: boolean;
 };
 
 // @public (undocumented)

--- a/src/platform/item/emote/adr74/emote-data-adr74.ts
+++ b/src/platform/item/emote/adr74/emote-data-adr74.ts
@@ -10,6 +10,7 @@ export type EmoteDataADR74 = {
   category: EmoteCategory
   representations: EmoteRepresentationADR74[]
   tags: string[]
+  loop: boolean
 }
 
 export namespace EmoteDataADR74 {
@@ -28,9 +29,12 @@ export namespace EmoteDataADR74 {
         items: EmoteRepresentationADR74.schema,
         minItems: 1
       },
-      category: EmoteCategory.schema
+      category: EmoteCategory.schema,
+      loop: {
+        type: 'boolean'
+      }
     },
-    required: ['category', 'tags', 'representations'] as any[],
+    required: ['category', 'tags', 'representations', 'loop'] as any[],
     additionalProperties: true
   }
 

--- a/src/platform/item/emote/emote-category.ts
+++ b/src/platform/item/emote/emote-category.ts
@@ -5,8 +5,7 @@ import {
 } from '../../../validation'
 
 export enum EmoteCategory {
-  SIMPLE = 'simple',
-  LOOP = 'loop'
+  SIMPLE = 'simple'
 }
 
 export namespace EmoteCategory {

--- a/test/platform/item/emote/emote.spec.ts
+++ b/test/platform/item/emote/emote.spec.ts
@@ -35,9 +35,10 @@ describe('Emote tests', () => {
   }
 
   const emoteDataADR74 = {
-    category: EmoteCategory.LOOP,
+    category: EmoteCategory.SIMPLE,
     representations: [representation],
-    tags: ['tag1']
+    tags: ['tag1'],
+    loop: false
   }
 
   const standardProps = {


### PR DESCRIPTION
According to what was discussed in the `Kick-off User Generate Emotes` meeting, removing `LOOP` category.