### PR TITLE
feat: added background option

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1122,7 +1122,8 @@ export type PreviewConfig = {
     type: PreviewType;
     background: {
         image?: string;
-        gradient?: string;
+        color: string;
+        transparent: boolean;
     };
     emote: PreviewEmote;
     camera: PreviewCamera;
@@ -1247,7 +1248,8 @@ export type PreviewOptions = {
     wheelZoom?: number | null;
     wheelPrecision?: number | null;
     wheelStart?: number | null;
-    transparentBackground?: boolean;
+    background?: string | null;
+    transparentBackground?: boolean | null;
     env?: PreviewEnv | null;
 };
 

--- a/src/dapps/preview/preview-config.ts
+++ b/src/dapps/preview/preview-config.ts
@@ -15,7 +15,8 @@ export type PreviewConfig = {
   type: PreviewType
   background: {
     image?: string
-    gradient?: string
+    color: string
+    transparent: boolean
   }
   emote: PreviewEmote
   camera: PreviewCamera

--- a/src/dapps/preview/preview-options.ts
+++ b/src/dapps/preview/preview-options.ts
@@ -27,6 +27,7 @@ export type PreviewOptions = {
   wheelZoom?: number | null
   wheelPrecision?: number | null
   wheelStart?: number | null
-  transparentBackground?: boolean
+  background?: string | null
+  transparentBackground?: boolean | null
   env?: PreviewEnv | null
 }


### PR DESCRIPTION
Added `options.background` to allow users to set a custom background color. Replaced `config.background.gradient?: string` with `config.background.color: string` and `config.background.transparent: boolean` since now the background is rendered by BabylonJS (in order to fix an issue with the glow layer), so the gradient is deprecated and whether or not the background is transparent is controlled from within the scene (that's why it's needed to pass the boolean that tells if it's transparent from the `config`).