### PR TITLE
feat: added types for controller and add wearables as blob

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1120,6 +1120,7 @@ export type PreviewConfig = {
     eyes: string;
     zoom: number;
     type: PreviewType;
+    face: boolean;
     background: {
         image?: string;
         color: string;
@@ -1195,10 +1196,12 @@ export namespace PreviewEnv {
 // Warning: (ae-missing-release-tag) "PreviewMessagePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type PreviewMessagePayload<T extends PreviewMessageType> = T extends PreviewMessageType.LOAD ? null : T extends PreviewMessageType.ERROR ? {
+export type PreviewMessagePayload<T extends PreviewMessageType> = T extends PreviewMessageType.READY ? null : T extends PreviewMessageType.LOAD ? null : T extends PreviewMessageType.ERROR ? {
     message: string;
 } : T extends PreviewMessageType.UPDATE ? {
     options: PreviewOptions;
+} : T extends PreviewMessageType.ADD_WEARABLE_WITH_BLOBS ? {
+    wearableWithBlobs: WearableWithBlobs;
 } : unknown;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
@@ -1206,6 +1209,8 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
 //
 // @public (undocumented)
 export enum PreviewMessageType {
+    // (undocumented)
+    ADD_WEARABLE_WITH_BLOBS = "add_wearable_with_blobs",
     // (undocumented)
     ERROR = "error",
     // (undocumented)
@@ -1241,7 +1246,6 @@ export type PreviewOptions = {
     emote?: PreviewEmote | null;
     camera?: PreviewCamera | null;
     autoRotateSpeed?: number | null;
-    centerBoundingBox?: boolean | null;
     offsetX?: number | null;
     offsetY?: number | null;
     offsetZ?: number | null;
@@ -1249,7 +1253,11 @@ export type PreviewOptions = {
     wheelPrecision?: number | null;
     wheelStart?: number | null;
     background?: string | null;
-    transparentBackground?: boolean | null;
+    disableBackground?: boolean | null;
+    disableAutoCenter?: boolean | null;
+    disableAutoRotate?: boolean | null;
+    disableFace?: boolean | null;
+    disableDefaultWearables?: boolean | null;
     env?: PreviewEnv | null;
 };
 
@@ -1836,7 +1844,8 @@ export namespace World {
 // src/dapps/preview/preview-config.ts:9:3 - (ae-incompatible-release-tags) The symbol "wearables" is marked as @public, but its signature references "WearableDefinition" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:10:3 - (ae-incompatible-release-tags) The symbol "bodyShape" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:15:3 - (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "PreviewType" which is marked as @alpha
-// src/dapps/preview/preview-message.ts:32:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:36:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:38:9 - (ae-forgotten-export) The symbol "WearableWithBlobs" needs to be exported by the entry point index.d.ts
 // src/dapps/sale.ts:18:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/sale.ts:19:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/sale.ts:42:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/preview/preview-config.ts
+++ b/src/dapps/preview/preview-config.ts
@@ -13,6 +13,7 @@ export type PreviewConfig = {
   eyes: string
   zoom: number
   type: PreviewType
+  face: boolean
   background: {
     image?: string
     color: string

--- a/src/dapps/preview/preview-controller.ts
+++ b/src/dapps/preview/preview-controller.ts
@@ -1,0 +1,20 @@
+import { PreviewSceneMetrics } from './preview-metrics'
+
+export interface IPreviewController {
+  scene: ISceneController
+  emote: IEmoteController
+}
+
+export interface ISceneController {
+  getScreenshot(width: number, height: number): Promise<string>
+  getMetrics(): PreviewSceneMetrics
+}
+
+export interface IEmoteController {
+  getLength(): number
+  isPlaying(): boolean
+  goTo(seconds: number): void
+  play(): void
+  pause(): void
+  stop(): void
+}

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -4,12 +4,14 @@ import {
   ValidateFunction
 } from '../../validation'
 import { PreviewOptions } from './preview-options'
+import { WearableWithBlobs } from './wearable-with-blobs'
 
 export enum PreviewMessageType {
   READY = 'ready',
   LOAD = 'load',
   ERROR = 'error',
-  UPDATE = 'update'
+  UPDATE = 'update',
+  ADD_WEARABLE_WITH_BLOBS = 'add_wearable_with_blobs'
 }
 
 /** @alpha */
@@ -24,12 +26,16 @@ export namespace PreviewMessageType {
 }
 
 export type PreviewMessagePayload<T extends PreviewMessageType> =
-  T extends PreviewMessageType.LOAD
+  T extends PreviewMessageType.READY
+    ? null
+    : T extends PreviewMessageType.LOAD
     ? null
     : T extends PreviewMessageType.ERROR
     ? { message: string }
     : T extends PreviewMessageType.UPDATE
     ? { options: PreviewOptions }
+    : T extends PreviewMessageType.ADD_WEARABLE_WITH_BLOBS
+    ? { wearableWithBlobs: WearableWithBlobs }
     : unknown
 
 export const sendMessage = <T extends PreviewMessageType>(

--- a/src/dapps/preview/preview-metrics.ts
+++ b/src/dapps/preview/preview-metrics.ts
@@ -1,0 +1,6 @@
+export type PreviewSceneMetrics = {
+  triangles: number
+  materials: number
+  meshes: number
+  textures: number
+}

--- a/src/dapps/preview/preview-options.ts
+++ b/src/dapps/preview/preview-options.ts
@@ -20,7 +20,6 @@ export type PreviewOptions = {
   emote?: PreviewEmote | null
   camera?: PreviewCamera | null
   autoRotateSpeed?: number | null
-  centerBoundingBox?: boolean | null
   offsetX?: number | null
   offsetY?: number | null
   offsetZ?: number | null
@@ -28,6 +27,10 @@ export type PreviewOptions = {
   wheelPrecision?: number | null
   wheelStart?: number | null
   background?: string | null
-  transparentBackground?: boolean | null
+  disableBackground?: boolean | null
+  disableAutoCenter?: boolean | null
+  disableAutoRotate?: boolean | null
+  disableFace?: boolean | null
+  disableDefaultWearables?: boolean | null
   env?: PreviewEnv | null
 }

--- a/src/dapps/preview/representation-with-blobs.ts
+++ b/src/dapps/preview/representation-with-blobs.ts
@@ -1,0 +1,7 @@
+import { RepresentationDefinition } from './representation-definition'
+
+/** @alpha */
+export type RepresentationWithBlobs = Omit<
+  RepresentationDefinition,
+  'contents'
+> & { contents: { key: string; blob: Blob }[] }

--- a/src/dapps/preview/wearable-with-blobs.ts
+++ b/src/dapps/preview/wearable-with-blobs.ts
@@ -1,0 +1,9 @@
+import { RepresentationWithBlobs } from './representation-with-blobs'
+import { WearableDefinition } from './wearable-definition'
+
+/** @alpha */
+export type WearableWithBlobs = Omit<WearableDefinition, 'data'> & {
+  data: Omit<WearableDefinition['data'], 'representations'> & {
+    representations: RepresentationWithBlobs[]
+  }
+}


### PR DESCRIPTION
This PR adds interfaces for the preview controller. It also adds a new message type `add_wearable_with_blobs` that will be used allow making previews of wearables that have not yet been uploaded to any server (ie. loading it from a .zip file). 
Finally it introduces a few new options that are necessary to create the silhoette avatar when generating thumbnails for emotes. 
I replaced some options like `centerBoundingBox` and `transparentBackground` with `disableAutoCenter` and `disableBackground` to keep the naming consistent with other `disable<Feature>` options. Since these are internal types and i'm the only one using them so far I think is safe to make this breaking change. The `wearable-preview` app will still support the old properties via query param to avoid breaking changes for now, but I'd like to remove them from the shared types to keep things cleaner.