### PR TITLE
feat: Add disableDefaultEmotes to the WearablePreview props

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1334,6 +1334,7 @@ export type PreviewOptions = {
     disableAutoRotate?: boolean | null;
     disableFace?: boolean | null;
     disableDefaultWearables?: boolean | null;
+    disableDefaultEmotes?: boolean | null;
     env?: PreviewEnv | null;
 };
 

--- a/src/dapps/preview/preview-options.ts
+++ b/src/dapps/preview/preview-options.ts
@@ -34,5 +34,6 @@ export type PreviewOptions = {
   disableAutoRotate?: boolean | null
   disableFace?: boolean | null
   disableDefaultWearables?: boolean | null
+  disableDefaultEmotes?: boolean | null
   env?: PreviewEnv | null
 }


### PR DESCRIPTION
As we can disable default wearables, let's also add a prop to disable default emotes. This will help to load emotes from blobs, avoiding having 2 animations loaded (the default and when the wanted one once the blob is passed to the iframe)