### PR TITLE
fix: old webpack parsers do not support .?

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "outDir": "dist",
-    "target": "es2020",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
`itemAsThirdParty?.merkleProof?.hashingKeys`