### PR TITLE
fix: Add active rental listing id to the nft type

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -990,6 +990,7 @@ export type NFT = {
     contractAddress: string;
     tokenId: string;
     activeOrderId: string | null;
+    openRentalId: string | null;
     owner: string;
     name: string;
     category: NFTCategory;
@@ -2153,11 +2154,11 @@ export namespace World {
 // src/dapps/mint.ts:20:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/mint.ts:21:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/mint.ts:41:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/nft.ts:46:7 - (ae-incompatible-release-tags) The symbol "bodyShapes" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
-// src/dapps/nft.ts:56:7 - (ae-incompatible-release-tags) The symbol "bodyShapes" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
-// src/dapps/nft.ts:59:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
-// src/dapps/nft.ts:60:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
-// src/dapps/nft.ts:87:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/nft.ts:48:7 - (ae-incompatible-release-tags) The symbol "bodyShapes" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
+// src/dapps/nft.ts:58:7 - (ae-incompatible-release-tags) The symbol "bodyShapes" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
+// src/dapps/nft.ts:61:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
+// src/dapps/nft.ts:62:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
+// src/dapps/nft.ts:89:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/order.ts:22:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/order.ts:23:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha
 // src/dapps/order.ts:36:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -277,6 +277,7 @@ export namespace NFT {
       'tokenId',
       'contractAddress',
       'activeOrderId',
+      'openRentalId',
       'owner',
       'name',
       'image',

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -17,7 +17,8 @@ export type NFT = {
   contractAddress: string
   tokenId: string
   activeOrderId: string | null
-  activeRentalListingId: string | null
+  /** The ID of the open rental listing associated with the NFT */
+  openRentalId: string | null
   owner: string
   name: string
   category: NFTCategory
@@ -117,7 +118,7 @@ export namespace NFT {
         type: 'string',
         nullable: true
       },
-      activeRentalListingId: {
+      openRentalId: {
         type: 'string',
         nullable: true
       },

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -17,6 +17,7 @@ export type NFT = {
   contractAddress: string
   tokenId: string
   activeOrderId: string | null
+  activeRentalListingId: string | null
   owner: string
   name: string
   category: NFTCategory
@@ -113,7 +114,11 @@ export namespace NFT {
         type: 'string'
       },
       activeOrderId: {
-        type: ['string'],
+        type: 'string',
+        nullable: true
+      },
+      activeRentalListingId: {
+        type: 'string',
         nullable: true
       },
       owner: {

--- a/test/dapps/nft.spec.ts
+++ b/test/dapps/nft.spec.ts
@@ -20,6 +20,7 @@ describe('NFT tests', () => {
       contractAddress: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
       activeOrderId:
         '0x2911f6ca62802491be38c859c6c3c8e3e3ae9732ad19032d4756a93f6fce88b1',
+      openRentalId: null,
       owner: '0xdfbf2c0bfbfafbfa81a47b736012c80af181142b',
       name: 'The Dope Spot',
       image: 'https://api.decentraland.org/v1/parcels/-63/-115/map.png',
@@ -58,6 +59,7 @@ describe('NFT tests', () => {
       contractAddress: '0x959e104e1a4db6317fa58f8295f586e1a978c297',
       activeOrderId:
         '0xedd3ac22aca9f0aecf39d42479dc982170bc2fefea282fe77b4ce4b63859add8',
+      openRentalId: 'e87f4f9a-19e1-4b6f-85bc-62921b503bfb',
       owner: '0x953c87eaee6889bf6623bf18031de42ba95a05cb',
       name: 'Fashion Hall',
       image: 'https://api.decentraland.org/v1/estates/4302/map.png',
@@ -120,6 +122,7 @@ describe('NFT tests', () => {
       contractAddress: '0xabb0ca6ee85825f6d7f549ef36bf571484c157c5',
       activeOrderId:
         '0x606a55e3aaa112d90a9474d73d8293dc8496d491eff32431b762a7ca46160fc0',
+      openRentalId: null,
       owner: '0x3bec652537ebf756d9c5f471f33b28278b1dd26d',
       name: 'HypnoVision',
       image:
@@ -161,6 +164,7 @@ describe('NFT tests', () => {
       contractAddress: '0x2a187453064356c898cae034eaed119e1663acb8',
       activeOrderId:
         '0x625dd3bd828a4060bc9bd049f2f06579cdae679f54e35e183e2152fe003c4569',
+      openRentalId: null,
       owner: '0x61d2911f0986ce12f4dddb61575600a9d3593c03',
       name: 'Rumors',
       image: '',
@@ -196,6 +200,7 @@ describe('NFT tests', () => {
       contractAddress: '0xabb0ca6ee85825f6d7f549ef36bf571484c157c5',
       activeOrderId:
         '0x606a55e3aaa112d90a9474d73d8293dc8496d491eff32431b762a7ca46160fc0',
+      openRentalId: null,
       owner: '0x3bec652537ebf756d9c5f471f33b28278b1dd26d',
       name: 'Head Explode',
       image:


### PR DESCRIPTION
This PR adds the activeRentalListingId into the NFT type to be able to identify the active rental id between all the rentals available.