### PR TITLE
chore: remove support for legacy emotes

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -2052,9 +2052,6 @@ export type WearableDefinition = Omit<Wearable, 'data'> & {
     data: Omit<Wearable['data'], 'representations'> & {
         representations: WearableRepresentationDefinition[];
     };
-    emoteDataV0?: {
-        loop: boolean;
-    };
 };
 
 // Warning: (ae-missing-release-tag) "WearableGender" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/dapps/preview/wearable-definition.ts
+++ b/src/dapps/preview/wearable-definition.ts
@@ -6,7 +6,4 @@ export type WearableDefinition = Omit<Wearable, 'data'> & {
   data: Omit<Wearable['data'], 'representations'> & {
     representations: WearableRepresentationDefinition[]
   }
-  emoteDataV0?: {
-    loop: boolean
-  }
 }


### PR DESCRIPTION
Remove deprecated `emoteDataV0` property from wearables. This is safe to remove since we don't use this anymore and all the emotes have been migrated to the ADR74 schema.