### PR TITLE
feat: converted single contract address filter into multiple

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -826,7 +826,7 @@ export type ItemFilters = {
     emoteCategory?: EmoteCategory;
     emoteGenders?: WearableGender[];
     emotePlayMode?: EmotePlayMode;
-    contractAddress?: string;
+    contractAddresses?: string[];
     itemId?: string;
     network?: Network;
 };

--- a/src/dapps/item.ts
+++ b/src/dapps/item.ts
@@ -53,7 +53,7 @@ export type ItemFilters = {
   emoteCategory?: EmoteCategory
   emoteGenders?: WearableGender[]
   emotePlayMode?: EmotePlayMode
-  contractAddress?: string
+  contractAddresses?: string[]
   itemId?: string
   network?: Network
 }


### PR DESCRIPTION
Renamed the `contractAddress` in the `ItemFilters` to `contractAddresses` and changed it to be an array.