### PR TITLE
fix: Change status to rental status

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1125,7 +1125,8 @@ export type NFTFilters = {
     tokenId?: string;
     itemId?: string;
     network?: Network;
-} & Pick<RentalsListingsFilterBy, 'tenant' | 'status'>;
+    rentalStatus?: RentalsListingsFilterBy['status'];
+} & Pick<RentalsListingsFilterBy, 'tenant'>;
 
 // Warning: (ae-missing-release-tag) "NFTSortBy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -89,7 +89,8 @@ export type NFTFilters = {
   tokenId?: string
   itemId?: string
   network?: Network
-} & Pick<RentalsListingsFilterBy, 'tenant' | 'status'>
+  rentalStatus?: RentalsListingsFilterBy['status']
+} & Pick<RentalsListingsFilterBy, 'tenant'>
 
 export enum NFTSortBy {
   NAME = 'name',


### PR DESCRIPTION
This PR changes the `status` NFT filter to `rentalStatus` to represent the filter better.