### PR TITLE
feat: Add emote animation playing event

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1333,7 +1333,9 @@ export enum PreviewEmoteEventType {
     // (undocumented)
     ANIMATION_PAUSE = "animation_pause",
     // (undocumented)
-    ANIMATION_PLAY = "animation_play"
+    ANIMATION_PLAY = "animation_play",
+    // (undocumented)
+    ANIMATION_PLAYING = "animation_playing"
 }
 
 // @alpha (undocumented)
@@ -1366,6 +1368,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
     error: string;
 } : T extends PreviewMessageType.EMOTE_EVENT ? {
     type: PreviewEmoteEventType;
+    payload?: any;
 } : unknown;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1368,7 +1368,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
     error: string;
 } : T extends PreviewMessageType.EMOTE_EVENT ? {
     type: PreviewEmoteEventType;
-    payload?: EmoteEventPayload<PreviewEmoteEventType>;
+    payload: EmoteEventPayload<PreviewEmoteEventType>;
 } : unknown;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1368,7 +1368,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
     error: string;
 } : T extends PreviewMessageType.EMOTE_EVENT ? {
     type: PreviewEmoteEventType;
-    payload?: number;
+    payload?: EmoteEventPayload<PreviewEmoteEventType>;
 } : unknown;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
@@ -2203,7 +2203,8 @@ export namespace World {
 // src/dapps/preview/preview-config.ts:11:3 - (ae-incompatible-release-tags) The symbol "wearables" is marked as @public, but its signature references "WearableDefinition" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:12:3 - (ae-incompatible-release-tags) The symbol "bodyShape" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:17:3 - (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "PreviewType" which is marked as @alpha
-// src/dapps/preview/preview-message.ts:38:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:39:9 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:73:9 - (ae-forgotten-export) The symbol "EmoteEventPayload" needs to be exported by the entry point index.d.ts
 // src/dapps/rentals-listings.ts:89:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/rentals-listings.ts:107:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/rentals-listings.ts:109:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1368,7 +1368,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
     error: string;
 } : T extends PreviewMessageType.EMOTE_EVENT ? {
     type: PreviewEmoteEventType;
-    payload?: any;
+    payload?: number;
 } : unknown;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/src/dapps/preview/preview-emote-event-payload.ts
+++ b/src/dapps/preview/preview-emote-event-payload.ts
@@ -1,0 +1,6 @@
+import { PreviewEmoteEventType } from './preview-emote-event-type'
+
+export type EmoteEventPayload<T extends PreviewEmoteEventType> =
+  T extends PreviewEmoteEventType.ANIMATION_PLAYING
+    ? { length: number }
+    : undefined

--- a/src/dapps/preview/preview-emote-event-type.ts
+++ b/src/dapps/preview/preview-emote-event-type.ts
@@ -8,7 +8,8 @@ export enum PreviewEmoteEventType {
   ANIMATION_PLAY = 'animation_play',
   ANIMATION_PAUSE = 'animation_pause',
   ANIMATION_LOOP = 'animation_loop',
-  ANIMATION_END = 'animation_end'
+  ANIMATION_END = 'animation_end',
+  ANIMATION_PLAYING = 'animation_playing'
 }
 
 /** @alpha */

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -70,7 +70,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> =
     : T extends PreviewMessageType.EMOTE_EVENT
     ? {
         type: PreviewEmoteEventType
-        payload?: EmoteEventPayload<PreviewEmoteEventType>
+        payload: EmoteEventPayload<PreviewEmoteEventType>
       }
     : unknown
 

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -67,7 +67,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> =
             error: string
           }
     : T extends PreviewMessageType.EMOTE_EVENT
-    ? { type: PreviewEmoteEventType }
+    ? { type: PreviewEmoteEventType; payload?: any }
     : unknown
 
 export const sendMessage = <T extends PreviewMessageType>(

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -67,7 +67,7 @@ export type PreviewMessagePayload<T extends PreviewMessageType> =
             error: string
           }
     : T extends PreviewMessageType.EMOTE_EVENT
-    ? { type: PreviewEmoteEventType; payload?: any }
+    ? { type: PreviewEmoteEventType; payload?: number }
     : unknown
 
 export const sendMessage = <T extends PreviewMessageType>(

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -4,6 +4,7 @@ import {
   ValidateFunction
 } from '../../validation'
 import { PreviewEmoteEventType } from './preview-emote-event-type'
+import { EmoteEventPayload } from './preview-emote-event-payload'
 import { PreviewOptions } from './preview-options'
 
 export enum PreviewMessageType {
@@ -67,7 +68,10 @@ export type PreviewMessagePayload<T extends PreviewMessageType> =
             error: string
           }
     : T extends PreviewMessageType.EMOTE_EVENT
-    ? { type: PreviewEmoteEventType; payload?: number }
+    ? {
+        type: PreviewEmoteEventType
+        payload?: EmoteEventPayload<PreviewEmoteEventType>
+      }
     : unknown
 
 export const sendMessage = <T extends PreviewMessageType>(


### PR DESCRIPTION
This PR adds the event `animation_playing` for emotes and the optional param `payload` to send data using the Emote Events emitter.