### PR TITLE
feat: add adjacentToRoad and distance to plaza NFT query params

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1154,6 +1154,9 @@ export type NFTFilters = {
     maxPrice?: string;
     minEstateSize?: number;
     maxEstateSize?: number;
+    minDistanceToPlaza?: number;
+    maxDistanceToPlaza?: number;
+    adjacentToRoad?: boolean;
 } & Pick<RentalsListingsFilterBy, 'tenant'>;
 
 // Warning: (ae-missing-release-tag) "NFTSortBy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/dapps/nft.ts
+++ b/src/dapps/nft.ts
@@ -97,6 +97,12 @@ export type NFTFilters = {
   minEstateSize?: number
   /** Filter NFTs with a max estate size */
   maxEstateSize?: number
+  /** Filter NFTs with at least this distance to a plaza */
+  minDistanceToPlaza?: number
+  /** Filter NFTs with at most this distance to a plaza */
+  maxDistanceToPlaza?: number
+  /** Filter that are next to a road */
+  adjacentToRoad?: boolean
 } & Pick<RentalsListingsFilterBy, 'tenant'>
 
 export enum NFTSortBy {


### PR DESCRIPTION
Add `minDistanceToPlaza`, `maxDistanceToPlaza` and `adjacentToRoad` properties to NFT filters. These will be use to implement the distance filter in land section