### PR TITLE
feat: expose notification type about Event Created for communities notifications

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -2585,6 +2585,8 @@ export enum NotificationType {
     // (undocumented)
     CREDITS_REMINDER_USAGE_24_HOURS = "credits_reminder_usage_24_hours",
     // (undocumented)
+    EVENT_CREATED = "event_created",
+    // (undocumented)
     EVENTS_STARTED = "events_started",
     // (undocumented)
     EVENTS_STARTS_SOON = "events_starts_soon",

--- a/src/platform/notifications/notifications.ts
+++ b/src/platform/notifications/notifications.ts
@@ -8,6 +8,7 @@ export enum NotificationType {
   BID_RECEIVED = 'bid_received',
   EVENTS_STARTED = 'events_started',
   EVENTS_STARTS_SOON = 'events_starts_soon',
+  EVENT_CREATED = 'event_created',
   GOVERNANCE_ANNOUNCEMENT = 'governance_announcement',
   GOVERNANCE_AUTHORED_PROPOSAL_FINISHED = 'governance_authored_proposal_finished',
   GOVERNANCE_COAUTHOR_REQUESTED = 'governance_coauthor_requested',


### PR DESCRIPTION
This PR adds a new Notification Type `EVENT_CREATED` to notify whenever an event has been approved and linked to a community.