### PR TITLE
fix: spring bone params properties

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -4913,8 +4913,8 @@ export type SpringBoneParams = {
     stiffness: number;
     gravityPower: number;
     gravityDir: [number, number, number];
-    dragForce: number;
-    center?: number;
+    drag: number;
+    center?: string;
 };
 
 // @alpha (undocumented)

--- a/src/dapps/preview/spring-bone-params.ts
+++ b/src/dapps/preview/spring-bone-params.ts
@@ -5,8 +5,8 @@ export type SpringBoneParams = {
   stiffness: number
   gravityPower: number
   gravityDir: [number, number, number]
-  dragForce: number
-  center?: number
+  drag: number
+  center?: string
 }
 
 /** @alpha */
@@ -22,10 +22,10 @@ export namespace SpringBoneParams {
         minItems: 3,
         maxItems: 3
       },
-      dragForce: { type: 'number', minimum: 0, maximum: 1 },
-      center: { type: 'integer', minimum: 0, nullable: true }
+      drag: { type: 'number', minimum: 0, maximum: 1 },
+      center: { type: 'string', nullable: true }
     },
-    required: ['stiffness', 'gravityPower', 'gravityDir', 'dragForce']
+    required: ['stiffness', 'gravityPower', 'gravityDir', 'drag']
   }
 
   export const validate: ValidateFunction<SpringBoneParams> = generateLazyValidator(schema)

--- a/test/dapps/preview/spring-bone-params.spec.ts
+++ b/test/dapps/preview/spring-bone-params.spec.ts
@@ -7,7 +7,7 @@ describe('SpringBoneParams tests', () => {
     stiffness: 1.5,
     gravityPower: 3.0,
     gravityDir: [0, -1, 0],
-    dragForce: 0.4
+    drag: 0.4
   }
 
   testTypeSignature(SpringBoneParams, springBoneParams)
@@ -19,11 +19,15 @@ describe('SpringBoneParams tests', () => {
   })
 
   it('validates with optional center field', () => {
-    expect(SpringBoneParams.validate({ ...springBoneParams, center: 5 })).toEqual(true)
+    expect(SpringBoneParams.validate({ ...springBoneParams, center: 'Avatar_Hips' })).toEqual(true)
   })
 
   it('validates without optional center field', () => {
     expect(SpringBoneParams.validate({ ...springBoneParams })).toEqual(true)
+  })
+
+  it('rejects center with wrong type', () => {
+    expect(SpringBoneParams.validate({ ...springBoneParams, center: 5 })).toEqual(false)
   })
 
   it('rejects stiffness out of range', () => {
@@ -36,9 +40,9 @@ describe('SpringBoneParams tests', () => {
     expect(SpringBoneParams.validate({ ...springBoneParams, gravityPower: -0.1 })).toEqual(false)
   })
 
-  it('rejects dragForce out of range', () => {
-    expect(SpringBoneParams.validate({ ...springBoneParams, dragForce: 1.1 })).toEqual(false)
-    expect(SpringBoneParams.validate({ ...springBoneParams, dragForce: -0.01 })).toEqual(false)
+  it('rejects drag out of range', () => {
+    expect(SpringBoneParams.validate({ ...springBoneParams, drag: 1.1 })).toEqual(false)
+    expect(SpringBoneParams.validate({ ...springBoneParams, drag: -0.01 })).toEqual(false)
   })
 
   it('rejects gravityDir with wrong length', () => {


### PR DESCRIPTION
# fix: spring bone params properties

This pull request updates the `SpringBoneParams` type and its validation logic to improve clarity and type safety, particularly around the `drag` and `center` fields. The changes also update the associated tests to reflect these adjustments.

**Type and validation changes:**

* Renamed the `dragForce` field to `drag` and changed its type and validation references throughout the codebase for consistency. (`src/dapps/preview/spring-bone-params.ts` [[1]](diffhunk://#diff-c247586d5fe071e3e9fa1c671582eebfdb163783cda9ed94371bdbb0411b601eL8-R9) [[2]](diffhunk://#diff-c247586d5fe071e3e9fa1c671582eebfdb163783cda9ed94371bdbb0411b601eL25-R28); `test/dapps/preview/spring-bone-params.spec.ts` [[3]](diffhunk://#diff-c92b6f87640dadf6da9b9b5741e5648a1b3abf533a5da6ea33b98d8d70590acdL10-R10) [[4]](diffhunk://#diff-c92b6f87640dadf6da9b9b5741e5648a1b3abf533a5da6ea33b98d8d70590acdL39-R45)
* Changed the `center` field from an optional `number` to an optional `string`, updating its validation schema accordingly. (`src/dapps/preview/spring-bone-params.ts` [[1]](diffhunk://#diff-c247586d5fe071e3e9fa1c671582eebfdb163783cda9ed94371bdbb0411b601eL8-R9) [[2]](diffhunk://#diff-c247586d5fe071e3e9fa1c671582eebfdb163783cda9ed94371bdbb0411b601eL25-R28)diffhunk://#diff-c92b6f87640dadf6da9b9b5741e5648a1b3abf533a5da6ea33b98d8d70590acdL39-R45)