### PR TITLE
feat: proximity chat scene permission toggle

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -2145,6 +2145,7 @@ export namespace EventStartsSoonEvent {
 export type FeatureToggles = {
     voiceChat?: EnabledDisabled;
     portableExperiences?: EnabledDisabled | PortableExperiencesToggles;
+    nearbyVoiceChat?: EnabledDisabled;
 };
 
 // @alpha (undocumented)

--- a/src/platform/scene/feature-toggles.ts
+++ b/src/platform/scene/feature-toggles.ts
@@ -10,7 +10,7 @@ export const portableExperiencesToggles: PortableExperiencesToggles[] = [...togg
 export type FeatureToggles = {
   voiceChat?: EnabledDisabled
   portableExperiences?: EnabledDisabled | PortableExperiencesToggles
-  proximityVoiceChat?: EnabledDisabled
+  nearbyVoiceChat?: EnabledDisabled
 }
 
 /** @alpha */
@@ -29,10 +29,11 @@ export namespace FeatureToggles {
         nullable: true,
         errorMessage: `valid options are ${portableExperiencesToggles.join(', ')}`
       },
-      proximityVoiceChat: {
+      nearbyVoiceChat: {
         type: 'string',
         enum: toggles,
-        nullable: true
+        nullable: true,
+        errorMessage: `valid options are ${toggles.join(', ')}`
       }
     },
     errorMessage: `valid options are ${toggles.join(', ')}`,

--- a/src/platform/scene/feature-toggles.ts
+++ b/src/platform/scene/feature-toggles.ts
@@ -10,6 +10,7 @@ export const portableExperiencesToggles: PortableExperiencesToggles[] = [...togg
 export type FeatureToggles = {
   voiceChat?: EnabledDisabled
   portableExperiences?: EnabledDisabled | PortableExperiencesToggles
+  proximityVoiceChat?: EnabledDisabled
 }
 
 /** @alpha */
@@ -27,6 +28,11 @@ export namespace FeatureToggles {
         enum: portableExperiencesToggles,
         nullable: true,
         errorMessage: `valid options are ${portableExperiencesToggles.join(', ')}`
+      },
+      proximityVoiceChat: {
+        type: 'string',
+        enum: toggles,
+        nullable: true
       }
     },
     errorMessage: `valid options are ${toggles.join(', ')}`,

--- a/test/platform/scenes/feature-toggles.spec.ts
+++ b/test/platform/scenes/feature-toggles.spec.ts
@@ -4,7 +4,8 @@ import { FeatureToggles } from '../../../src'
 describe('Feature toggles tests', () => {
   const toggles: FeatureToggles = {
     voiceChat: 'disabled',
-    portableExperiences: 'hideUi'
+    portableExperiences: 'hideUi',
+    nearbyVoiceChat: 'disabled'
   }
 
   it('type has a "schema" object', () => {
@@ -53,6 +54,25 @@ describe('Feature toggles tests', () => {
       {
         instancePath: '/portableExperiences',
         message: 'valid options are enabled, disabled, hideUi'
+      }
+    ])
+  })
+
+  it('nearbyVoiceChat with valid values passes', () => {
+    expect(FeatureToggles.validate({ nearbyVoiceChat: 'enabled' })).toEqual(true)
+    expect(FeatureToggles.validate({ nearbyVoiceChat: 'disabled' })).toEqual(true)
+  })
+
+  it('nearbyVoiceChat with invalid value fails', () => {
+    expect(FeatureToggles.validate({ nearbyVoiceChat: 'not-valid' })).toEqual(false)
+  })
+
+  it('nearbyVoiceChat error message', () => {
+    expect(FeatureToggles.validate({ nearbyVoiceChat: 'not-valid' })).toEqual(false)
+    expect(FeatureToggles.validate.errors).toMatchObject([
+      {
+        instancePath: '/nearbyVoiceChat',
+        message: 'valid options are enabled, disabled'
       }
     ])
   })


### PR DESCRIPTION
## Summary

- Adds `nearbyVoiceChat` as a new optional `enabled | disabled` toggle to `FeatureToggles` in `src/platform/scene/feature-toggles.ts`
- Follows the same convention as the existing `voiceChat` toggle (plain `EnabledDisabled`, reuses the shared `toggles` array)
- Includes `errorMessage` field consistent with `portableExperiences` entry
- Updated `report/schemas.api.md` via `npm run refresh-api`
- No changes needed in `scene.ts` — `Scene.featureToggles` picks up new fields automatically
- Both type and schema entry added; field is optional (`@alpha`, non-breaking)

## Changes

```
src/platform/scene/feature-toggles.ts | 7 ++++---
report/schemas.api.md                 | 1 +
```

## Usage in scene.json

```json
{
  "featureToggles": {
    "nearbyVoiceChat": "disabled"
  }
}
```

## Testing

- `tsc` build: ✅ no errors
- `mocha` tests: ✅ 802 passing
- `eslint` lint: ✅ no warnings
- `npm run check-api`: ✅ API report matches

## Next steps

Once merged and published, downstream consumers (`@dcl/sdk-commands`, `js-sdk-toolchain`) will need a `@dcl/schemas` dep bump to pick up the new type.
