### PR TITLE
feat!: enrich deployment events with pointers, entityType and world name

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -5766,8 +5766,10 @@ export type WorldDeploymentEvent = BaseEvent & {
     subType: Events.SubType.Worlds.DEPLOYMENT;
     entity: {
         entityId: string;
+        pointers: string[];
         authChain: AuthChain;
     };
+    worldName: string;
     contentServerUrls?: string[];
     force?: boolean;
     animation?: string;

--- a/src/misc/deployments-to-sqs.ts
+++ b/src/misc/deployments-to-sqs.ts
@@ -1,4 +1,5 @@
 import { JSONSchema, generateLazyValidator, ValidateFunction } from '../validation'
+import { EntityType } from '../platform/entity'
 import { AuthChain } from './auth-chain'
 
 /**
@@ -7,6 +8,8 @@ import { AuthChain } from './auth-chain'
 export type DeploymentToSqs = {
   entity: {
     entityId: string
+    entityType: EntityType
+    pointers: string[]
     authChain: AuthChain
   }
   lods?: string[]
@@ -26,9 +29,11 @@ export namespace DeploymentToSqs {
     properties: {
       entity: {
         type: 'object',
-        required: ['entityId', 'authChain'],
+        required: ['entityId', 'entityType', 'pointers', 'authChain'],
         properties: {
           entityId: { type: 'string' },
+          entityType: { type: 'string', enum: Object.values(EntityType) },
+          pointers: { type: 'array', items: { type: 'string', minLength: 1 }, minItems: 1 },
           authChain: AuthChain.schema
         },
         additionalProperties: true

--- a/src/platform/events/world.ts
+++ b/src/platform/events/world.ts
@@ -67,8 +67,10 @@ export type WorldDeploymentEvent = BaseEvent & {
   subType: Events.SubType.Worlds.DEPLOYMENT
   entity: {
     entityId: string
+    pointers: string[]
     authChain: AuthChain
   }
+  worldName: string
   contentServerUrls?: string[]
   force?: boolean
   animation?: string
@@ -267,16 +269,21 @@ export namespace WorldDeploymentEvent {
       timestamp: { type: 'number', minimum: 0 },
       entity: {
         type: 'object',
-        properties: { entityId: { type: 'string' }, authChain: AuthChain.schema },
+        properties: {
+          entityId: { type: 'string' },
+          pointers: { type: 'array', items: { type: 'string', minLength: 1 }, minItems: 1 },
+          authChain: AuthChain.schema
+        },
         additionalProperties: true,
-        required: ['entityId', 'authChain']
+        required: ['entityId', 'pointers', 'authChain']
       },
+      worldName: { type: 'string' },
       contentServerUrls: { type: 'array', items: { type: 'string' }, nullable: true },
       force: { type: 'boolean', nullable: true },
       animation: { type: 'string', nullable: true },
       lods: { type: 'array', items: { type: 'string' }, nullable: true }
     },
-    required: ['type', 'subType', 'key', 'timestamp', 'entity'],
+    required: ['type', 'subType', 'key', 'timestamp', 'entity', 'worldName'],
     additionalProperties: false
   }
 

--- a/test/misc/deployments-to-sqs.spec.ts
+++ b/test/misc/deployments-to-sqs.spec.ts
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import { AuthChain, AuthLinkType } from '../../src'
+import { AuthChain, AuthLinkType, EntityType } from '../../src'
 import { DeploymentToSqs } from '../../src/misc/deployments-to-sqs'
 import { expectValidationFailureWithErrors } from '../test-utils'
 
@@ -29,6 +29,8 @@ describe('deployments-to-sqs', () => {
     const deploymentToSqs: DeploymentToSqs = {
       entity: {
         entityId: 'baz',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         authChain: chain
       },
       contentServerUrls: []
@@ -40,6 +42,8 @@ describe('deployments-to-sqs', () => {
     const deploymentToSqs: DeploymentToSqs = {
       entity: {
         entityId: 'baz',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         authChain: chain
       },
       contentServerUrls: ['https://peer.decentraland.org']
@@ -51,7 +55,8 @@ describe('deployments-to-sqs', () => {
     const deploymentToSqs = {
       entity: {
         entityId: 'baz',
-        entityType: 'scene',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         metadata: {},
         authChain: chain
       },
@@ -60,10 +65,36 @@ describe('deployments-to-sqs', () => {
     expect(DeploymentToSqs.validate(deploymentToSqs)).toEqual(true)
   })
 
+  it('valid with wearable entity and urn pointer', () => {
+    const deploymentToSqs: DeploymentToSqs = {
+      entity: {
+        entityId: 'baz',
+        entityType: EntityType.WEARABLE,
+        pointers: ['urn:decentraland:matic:collections-v2:0x1234567890abcdef1234567890abcdef12345678:0'],
+        authChain: chain
+      }
+    }
+    expect(DeploymentToSqs.validate(deploymentToSqs)).toEqual(true)
+  })
+
+  it('valid with emote entity and urn pointer', () => {
+    const deploymentToSqs: DeploymentToSqs = {
+      entity: {
+        entityId: 'baz',
+        entityType: EntityType.EMOTE,
+        pointers: ['urn:decentraland:matic:collections-v2:0x1234567890abcdef1234567890abcdef12345678:1'],
+        authChain: chain
+      }
+    }
+    expect(DeploymentToSqs.validate(deploymentToSqs)).toEqual(true)
+  })
+
   it('valid if no contentServerUrls', () => {
     const deploymentToSqs = {
       entity: {
         entityId: 'someId',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         authChain: chain
       }
     }
@@ -73,6 +104,8 @@ describe('deployments-to-sqs', () => {
   it('invalid if no entityId', () => {
     const deploymentToSqs = {
       entity: {
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         authChain: chain
       },
       contentServerUrls: ['https://peer.decentraland.org']
@@ -85,7 +118,9 @@ describe('deployments-to-sqs', () => {
   it('invalid if no authChain', () => {
     const deploymentToSqs = {
       entity: {
-        entityId: 'someId'
+        entityId: 'someId',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0']
       },
       contentServerUrls: ['https://peer.decentraland.org']
     }
@@ -94,10 +129,64 @@ describe('deployments-to-sqs', () => {
     ])
   })
 
+  it('invalid if no entityType', () => {
+    const deploymentToSqs = {
+      entity: {
+        entityId: 'someId',
+        pointers: ['0,0'],
+        authChain: chain
+      }
+    }
+    expectValidationFailureWithErrors(DeploymentToSqs.validate, deploymentToSqs, [
+      "must have required property 'entityType'"
+    ])
+  })
+
+  it('invalid if entityType is not a known value', () => {
+    const deploymentToSqs = {
+      entity: {
+        entityId: 'someId',
+        entityType: 'not-a-real-type',
+        pointers: ['0,0'],
+        authChain: chain
+      }
+    }
+    expectValidationFailureWithErrors(DeploymentToSqs.validate, deploymentToSqs, [
+      'must be equal to one of the allowed values'
+    ])
+  })
+
+  it('invalid if no pointers', () => {
+    const deploymentToSqs = {
+      entity: {
+        entityId: 'someId',
+        entityType: EntityType.SCENE,
+        authChain: chain
+      }
+    }
+    expectValidationFailureWithErrors(DeploymentToSqs.validate, deploymentToSqs, [
+      "must have required property 'pointers'"
+    ])
+  })
+
+  it('invalid if pointers is empty', () => {
+    const deploymentToSqs = {
+      entity: {
+        entityId: 'someId',
+        entityType: EntityType.SCENE,
+        pointers: [],
+        authChain: chain
+      }
+    }
+    expectValidationFailureWithErrors(DeploymentToSqs.validate, deploymentToSqs, ['must NOT have fewer than 1 items'])
+  })
+
   it('valid with lods', () => {
     const deploymentToSqs: DeploymentToSqs = {
       entity: {
         entityId: 'baz',
+        entityType: EntityType.SCENE,
+        pointers: ['0,0'],
         authChain: chain
       },
       lods: ['https://cdn.test/file1.pbx', 'https://cdn.test/file2.pbx']

--- a/test/platform/events/world.spec.ts
+++ b/test/platform/events/world.spec.ts
@@ -1,10 +1,34 @@
 import expect from 'expect'
 import {
+  AuthChain,
+  AuthLinkType,
+  Events,
+  WorldDeploymentEvent,
   WorldSpawnCoordinateSetEvent,
   WorldScenesUndeploymentEvent,
-  WorldUndeploymentEvent,
-  Events
+  WorldUndeploymentEvent
 } from '../../../src'
+
+const chain: AuthChain = [
+  {
+    type: AuthLinkType.SIGNER,
+    payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+    signature: ''
+  },
+  {
+    type: AuthLinkType.ECDSA_EIP_1654_EPHEMERAL,
+    payload:
+      'Decentraland Login\nEphemeral address: 0x69fBdE5Da06eb76e8E7F6Fd2FEEd968F28b951a5\nExpiration: Tue Aug 06 7112 10:14:51 GMT-0300 (Argentina Standard Time)',
+    signature:
+      '0x03524dbe44d19aacc8162b4d5d17820c370872de7bfd25d1add2b842adb1de546b454fc973b6d215883c30f4c21774ae71683869317d773f27e6bfaa9a2a05101b36946c3444914bb93f17a29d88e2449bcafdb6478b4835102c522197fa6f63d13ce5ab1d5c11c95db0c210fb4380995dff672392e5569c86d7c6bb2a44c53a151c'
+  },
+  {
+    type: AuthLinkType.ECDSA_PERSONAL_SIGNED_ENTITY,
+    payload: 'QmUsqJaHc5HQaBrojhBdjF4fr5MQc6CqhwZjqwhVRftNAo',
+    signature:
+      '0xd73b0315dd39080d9b6d1a613a56732a75d68d2cef2a38f3b7be12bdab3c59830c92c6bdf394dcb47ba1aa736e0338cf9112c9eee59dbe4109b8af6a993b12d71b'
+  }
+]
 
 describe('when validating the WorldSpawnCoordinateSetEvent', () => {
   describe('and the event is valid', () => {
@@ -628,6 +652,117 @@ describe('when validating the WorldUndeploymentEvent', () => {
 
     it('should return false', () => {
       expect(WorldUndeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+})
+
+describe('when validating the WorldDeploymentEvent', () => {
+  describe('and the event is valid', () => {
+    let event: WorldDeploymentEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.DEPLOYMENT,
+        key: 'my-world.dcl.eth',
+        timestamp: 1,
+        entity: {
+          entityId: 'bafkreieu7mh6tinryekouyg75bhruggrn3a6k4oqknvrw6scsfymqihbcy',
+          pointers: ['0,0', '0,1'],
+          authChain: chain
+        },
+        worldName: 'my-world.dcl.eth',
+        contentServerUrls: ['https://worlds-content-server.decentraland.org']
+      }
+    })
+
+    it('should return true', () => {
+      expect(WorldDeploymentEvent.validate(event)).toEqual(true)
+    })
+  })
+
+  describe('and the worldName is missing', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.DEPLOYMENT,
+        key: 'key',
+        timestamp: 1,
+        entity: {
+          entityId: 'bafkreieu7mh6tinryekouyg75bhruggrn3a6k4oqknvrw6scsfymqihbcy',
+          pointers: ['0,0'],
+          authChain: chain
+        }
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldDeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and the entity pointers are missing', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.DEPLOYMENT,
+        key: 'key',
+        timestamp: 1,
+        entity: {
+          entityId: 'bafkreieu7mh6tinryekouyg75bhruggrn3a6k4oqknvrw6scsfymqihbcy',
+          authChain: chain
+        },
+        worldName: 'my-world.dcl.eth'
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldDeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and the entity pointers array is empty', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.DEPLOYMENT,
+        key: 'key',
+        timestamp: 1,
+        entity: {
+          entityId: 'bafkreieu7mh6tinryekouyg75bhruggrn3a6k4oqknvrw6scsfymqihbcy',
+          pointers: [],
+          authChain: chain
+        },
+        worldName: 'my-world.dcl.eth'
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldDeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and the entity is missing', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.DEPLOYMENT,
+        key: 'key',
+        timestamp: 1,
+        worldName: 'my-world.dcl.eth'
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldDeploymentEvent.validate(event)).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

Extends the deployment event schemas so downstream consumers (primarily the asset-bundle-converter) can make decisions from the event payload without round-tripping to the content server or guessing from URLs.

- **`DeploymentToSqs`** — `entity.entityType` (required) and `entity.pointers` (required, min 1). For wearables/emotes the URN is `pointers[0]`.
- **`WorldDeploymentEvent`** — `entity.pointers` (required, min 1) and top-level `worldName` (required).

### Why

- **Wearable / emote URN**: consumers need the URN alongside the entity id. Wearable and emote entities use URN-style pointers, so `pointers[0]` is the URN.
- **World scenes**: the asset-bundle-converter currently infers "world vs genesis-city" from a substring check on `contentServerUrls[0]`. Making the scene pointers + world name explicit removes that heuristic and unlocks proper per-world handling.
- **Genesis city scenes**: pointers were already being attached by the catalyst publisher through the `additionalProperties: true` escape hatch, but were untyped. Formalizing them avoids the catalyst fetch the converter does today only to read `entity.type` / `entity.pointers`.

### Breaking change

This is a breaking change to the public types: both `entity.entityType` + `entity.pointers` (on `DeploymentToSqs`) and `entity.pointers` + `worldName` (on `WorldDeploymentEvent`) are now required. Publishers and consumers need to upgrade together. Rollout order:

1. Land this schema release.
2. Upgrade publishers: `deployments-to-sqs` (catalyst → SQS) and `worlds-content-server` (worlds → SNS) to populate the new fields.
3. Upgrade consumer `asset-bundle-converter` to read the fields instead of deriving them.

## Test plan

- [x] `npm run build` passes.
- [x] `npm test` passes (816 tests).
- [x] `npm run refresh-api` regenerates `report/schemas.api.md`.
- [x] New test cases cover: valid scene/wearable/emote `DeploymentToSqs`, missing `entityType`, unknown `entityType`, missing `pointers`, empty `pointers`, valid `WorldDeploymentEvent`, missing `worldName`, missing/empty `pointers`, missing `entity`.