### PR TITLE
feat: add EventApprovedEvent and EventRejectedEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "26.2.0",
   "name": "@dcl/schemas",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "26.2.0",
+  "version": "0.0.0",
   "name": "@dcl/schemas",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1735,8 +1735,33 @@ export namespace EthAddress {
 // Warning: (ae-missing-release-tag) "Event" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type Event_2 = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | CreditsOnDemandEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | CommunityStreamingEndedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | UserBannedFromSceneEvent | UserUnbannedFromSceneEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | CreditsNewSeasonReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberLeftEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | CommunityOwnershipTransferredEvent | CommunityPostAddedEvent | CommunityVoiceChatStartedEvent | PhotoTakenEvent | PhotoPrivacyChangedEvent | AuthIdentifyEvent | EventCreatedEvent | EventStartedEvent | EventStartsSoonEvent | EventEndedEvent | GovernanceProposalEnactedEvent | GovernanceCoauthorRequestedEvent | GovernancePitchPassedEvent | GovernanceTenderPassedEvent | GovernanceAuthoredProposalFinishedEvent | GovernanceVotingEndedVoterEvent | GovernanceNewCommentOnProposalEvent | GovernanceNewCommentOnProjectUpdatedEvent | GovernanceWhaleVoteEvent | GovernanceVotedOnBehalfEvent | GovernanceCliffEndedEvent | WorldsPermissionGrantedEvent | WorldsPermissionRevokedEvent | WorldsAccessRestoredEvent | WorldsAccessRestrictedEvent | WorldsMissingResourcesEvent | TransferReceivedEvent | TipReceivedEvent | UserBanCreatedEvent | UserBanLiftedEvent | UserWarningCreatedEvent;
+type Event_2 = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | CreditsOnDemandEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | CommunityStreamingEndedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | UserBannedFromSceneEvent | UserUnbannedFromSceneEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | CreditsNewSeasonReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberLeftEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | CommunityOwnershipTransferredEvent | CommunityPostAddedEvent | CommunityVoiceChatStartedEvent | PhotoTakenEvent | PhotoPrivacyChangedEvent | AuthIdentifyEvent | EventCreatedEvent | EventStartedEvent | EventStartsSoonEvent | EventEndedEvent | EventApprovedEvent | EventRejectedEvent | GovernanceProposalEnactedEvent | GovernanceCoauthorRequestedEvent | GovernancePitchPassedEvent | GovernanceTenderPassedEvent | GovernanceAuthoredProposalFinishedEvent | GovernanceVotingEndedVoterEvent | GovernanceNewCommentOnProposalEvent | GovernanceNewCommentOnProjectUpdatedEvent | GovernanceWhaleVoteEvent | GovernanceVotedOnBehalfEvent | GovernanceCliffEndedEvent | WorldsPermissionGrantedEvent | WorldsPermissionRevokedEvent | WorldsAccessRestoredEvent | WorldsAccessRestrictedEvent | WorldsMissingResourcesEvent | TransferReceivedEvent | TipReceivedEvent | UserBanCreatedEvent | UserBanLiftedEvent | UserWarningCreatedEvent;
 export { Event_2 as Event }
+
+// Warning: (ae-missing-release-tag) "EventApprovedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EventApprovedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EventApprovedEvent = BaseEvent & {
+    type: Events.Type.EVENT;
+    subType: Events.SubType.Event.EVENT_APPROVED;
+    metadata: {
+        host: string;
+        title: string;
+        description: string;
+        name: string;
+        image: string;
+        link: string;
+    };
+};
+
+// @public (undocumented)
+export namespace EventApprovedEvent {
+    const // (undocumented)
+    schema: JSONSchema<EventApprovedEvent>;
+    const // (undocumented)
+    validate: ValidateFunction<EventApprovedEvent>;
+}
 
 // Warning: (ae-missing-release-tag) "EventCreatedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "EventCreatedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1784,6 +1809,31 @@ export namespace EventEndedEvent {
     schema: JSONSchema<EventEndedEvent>;
     const // (undocumented)
     validate: ValidateFunction<EventEndedEvent>;
+}
+
+// Warning: (ae-missing-release-tag) "EventRejectedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EventRejectedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EventRejectedEvent = BaseEvent & {
+    type: Events.Type.EVENT;
+    subType: Events.SubType.Event.EVENT_REJECTED;
+    metadata: {
+        host: string;
+        title: string;
+        description: string;
+        name: string;
+        image: string;
+        reason: string;
+    };
+};
+
+// @public (undocumented)
+export namespace EventRejectedEvent {
+    const // (undocumented)
+    schema: JSONSchema<EventRejectedEvent>;
+    const // (undocumented)
+    validate: ValidateFunction<EventRejectedEvent>;
 }
 
 // Warning: (ae-missing-release-tag) "Events" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1924,9 +1974,13 @@ export namespace Events {
         // (undocumented)
         export enum Event {
             // (undocumented)
+            EVENT_APPROVED = "event-approved",
+            // (undocumented)
             EVENT_CREATED = "event-created",
             // (undocumented)
             EVENT_ENDED = "event-ended",
+            // (undocumented)
+            EVENT_REJECTED = "event-rejected",
             // (undocumented)
             EVENT_STARTED = "event-started",
             // (undocumented)

--- a/src/platform/events/base.ts
+++ b/src/platform/events/base.ts
@@ -67,7 +67,14 @@ import {
   CommunityStreamingEndedEvent
 } from './streaming'
 import { AuthIdentifyEvent } from './web'
-import { EventCreatedEvent, EventStartedEvent, EventStartsSoonEvent, EventEndedEvent } from './event'
+import {
+  EventCreatedEvent,
+  EventStartedEvent,
+  EventStartsSoonEvent,
+  EventEndedEvent,
+  EventApprovedEvent,
+  EventRejectedEvent
+} from './event'
 import {
   GovernanceProposalEnactedEvent,
   GovernanceCoauthorRequestedEvent,
@@ -245,7 +252,9 @@ export namespace Events {
       EVENT_CREATED = 'event-created',
       EVENT_STARTS_SOON = 'event-starts-soon',
       EVENT_STARTED = 'event-started',
-      EVENT_ENDED = 'event-ended'
+      EVENT_ENDED = 'event-ended',
+      EVENT_APPROVED = 'event-approved',
+      EVENT_REJECTED = 'event-rejected'
     }
 
     export enum Governance {
@@ -361,6 +370,8 @@ export type Event =
   | EventStartedEvent
   | EventStartsSoonEvent
   | EventEndedEvent
+  | EventApprovedEvent
+  | EventRejectedEvent
   | GovernanceProposalEnactedEvent
   | GovernanceCoauthorRequestedEvent
   | GovernancePitchPassedEvent

--- a/src/platform/events/event.ts
+++ b/src/platform/events/event.ts
@@ -55,6 +55,32 @@ export type EventEndedEvent = BaseEvent & {
   }
 }
 
+export type EventApprovedEvent = BaseEvent & {
+  type: Events.Type.EVENT
+  subType: Events.SubType.Event.EVENT_APPROVED
+  metadata: {
+    host: string
+    title: string
+    description: string
+    name: string
+    image: string
+    link: string
+  }
+}
+
+export type EventRejectedEvent = BaseEvent & {
+  type: Events.Type.EVENT
+  subType: Events.SubType.Event.EVENT_REJECTED
+  metadata: {
+    host: string
+    title: string
+    description: string
+    name: string
+    image: string
+    reason: string
+  }
+}
+
 export namespace EventStartedEvent {
   export const schema: JSONSchema<EventStartedEvent> = {
     type: 'object',
@@ -170,4 +196,60 @@ export namespace EventEndedEvent {
     additionalProperties: false
   }
   export const validate: ValidateFunction<EventEndedEvent> = generateLazyValidator(schema)
+}
+
+export namespace EventApprovedEvent {
+  export const schema: JSONSchema<EventApprovedEvent> = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', const: Events.Type.EVENT },
+      subType: { type: 'string', const: Events.SubType.Event.EVENT_APPROVED },
+      key: { type: 'string' },
+      timestamp: { type: 'number', minimum: 0 },
+      metadata: {
+        type: 'object',
+        properties: {
+          host: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          name: { type: 'string' },
+          image: { type: 'string' },
+          link: { type: 'string' }
+        },
+        required: ['host', 'name', 'image', 'link'],
+        additionalProperties: false
+      }
+    },
+    required: ['type', 'subType', 'key', 'timestamp', 'metadata'],
+    additionalProperties: false
+  }
+  export const validate: ValidateFunction<EventApprovedEvent> = generateLazyValidator(schema)
+}
+
+export namespace EventRejectedEvent {
+  export const schema: JSONSchema<EventRejectedEvent> = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', const: Events.Type.EVENT },
+      subType: { type: 'string', const: Events.SubType.Event.EVENT_REJECTED },
+      key: { type: 'string' },
+      timestamp: { type: 'number', minimum: 0 },
+      metadata: {
+        type: 'object',
+        properties: {
+          host: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          name: { type: 'string' },
+          image: { type: 'string' },
+          reason: { type: 'string' }
+        },
+        required: ['host', 'name', 'image', 'reason'],
+        additionalProperties: false
+      }
+    },
+    required: ['type', 'subType', 'key', 'timestamp', 'metadata'],
+    additionalProperties: false
+  }
+  export const validate: ValidateFunction<EventRejectedEvent> = generateLazyValidator(schema)
 }


### PR DESCRIPTION
Adds two new event types for the event moderation flow:

- `EventApprovedEvent` (subType `event-approved`) — metadata: `host`, `title`, `description`, `name`, `image`, `link`. Required: `host`, `name`, `image`, `link`.
- `EventRejectedEvent` (subType `event-rejected`) — metadata: `host`, `title`, `description`, `name`, `image`, `reason`. Required: `host`, `name`, `image`, `reason`.

Both are added to `Events.SubType.Event` and to the top-level `Event` union, with `schema` + `validate` namespaces following the existing pattern. `NotificationType.EVENT_APPROVED` / `EVENT_REJECTED` already exist and were not modified. `report/schemas.api.md` regenerated via `npm run refresh-api`.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (827 passing)