### PR TITLE
feat: remove redundant name field from event approved/rejected metadata

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1749,7 +1749,6 @@ export type EventApprovedEvent = BaseEvent & {
         host: string;
         title: string;
         description: string;
-        name: string;
         image: string;
         link: string;
     };
@@ -1822,7 +1821,6 @@ export type EventRejectedEvent = BaseEvent & {
         host: string;
         title: string;
         description: string;
-        name: string;
         image: string;
         reason: string;
     };

--- a/src/platform/events/event.ts
+++ b/src/platform/events/event.ts
@@ -62,7 +62,6 @@ export type EventApprovedEvent = BaseEvent & {
     host: string
     title: string
     description: string
-    name: string
     image: string
     link: string
   }
@@ -75,7 +74,6 @@ export type EventRejectedEvent = BaseEvent & {
     host: string
     title: string
     description: string
-    name: string
     image: string
     reason: string
   }
@@ -212,11 +210,10 @@ export namespace EventApprovedEvent {
           host: { type: 'string' },
           title: { type: 'string' },
           description: { type: 'string' },
-          name: { type: 'string' },
           image: { type: 'string' },
           link: { type: 'string' }
         },
-        required: ['host', 'name', 'image', 'link'],
+        required: ['host', 'title', 'image', 'link'],
         additionalProperties: false
       }
     },
@@ -240,11 +237,10 @@ export namespace EventRejectedEvent {
           host: { type: 'string' },
           title: { type: 'string' },
           description: { type: 'string' },
-          name: { type: 'string' },
           image: { type: 'string' },
           reason: { type: 'string' }
         },
-        required: ['host', 'name', 'image', 'reason'],
+        required: ['host', 'title', 'image', 'reason'],
         additionalProperties: false
       }
     },


### PR DESCRIPTION
Removes the \`name\` field from \`EventApprovedEvent\` and \`EventRejectedEvent\` metadata. It was redundant — the event title is already conveyed via \`title\`, and downstream consumers (notifications-workers email templates) can drive copy off \`title\` instead.

The \`required\` arrays now use \`title\` instead of \`name\`. Other Event* types (\`EventCreatedEvent\`, \`EventStartedEvent\`, etc.) are unchanged because for those \`title\` is a generic notification header ("Event started") and \`name\` is the actual event name — those two are not interchangeable in that context.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 827/827 passed
- [x] \`npm run refresh-api\` regenerated \`report/schemas.api.md\`
- [x] \`npm run lint\` clean