### PR TITLE
feat: add exportVRM method to PreviewController.scene

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -2728,6 +2728,8 @@ export interface ISceneController {
     changeZoom(zoom: number): Promise<void>;
     // (undocumented)
     cleanup(): Promise<void>;
+    // (undocumented)
+    exportVRM(): Promise<void>;
     // Warning: (ae-incompatible-release-tags) The symbol "getMetrics" is marked as @public, but its signature references "Metrics" which is marked as @alpha
     //
     // (undocumented)
@@ -4072,11 +4074,13 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
 } : T extends PreviewMessageType.UPDATE ? {
     options: PreviewOptions;
 } : T extends PreviewMessageType.CONTROLLER_REQUEST ? {
-    id: string;
-    namespace: 'scene' | 'emote' | 'physics';
-    method: 'getScreenshot' | 'getMetrics' | 'changeZoom' | 'changeCameraPosition' | 'panCamera' | 'cleanup' | 'getLength' | 'isPlaying' | 'play' | 'pause' | 'stop' | 'goTo' | 'enableSound' | 'disableSound' | 'hasSound' | 'setUsername' | 'setSpringBonesParams';
-    params: any[];
-} : T extends PreviewMessageType.CONTROLLER_RESPONSE ? {
+    [K in keyof IPreviewController]: {
+        id: string;
+        namespace: K;
+        method: keyof IPreviewController[K];
+        params: any[];
+    };
+}[keyof IPreviewController] : T extends PreviewMessageType.CONTROLLER_RESPONSE ? {
     id: string;
     ok: true;
     result: any;
@@ -6106,8 +6110,8 @@ export namespace WorldUndeploymentEvent {
 // src/dapps/preview/preview-config.ts:21:3 - (ae-incompatible-release-tags) The symbol "wearables" is marked as @public, but its signature references "WearableDefinition" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:22:3 - (ae-incompatible-release-tags) The symbol "bodyShape" is marked as @public, but its signature references "BodyShape" which is marked as @alpha
 // src/dapps/preview/preview-config.ts:27:3 - (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "PreviewType" which is marked as @alpha
-// src/dapps/preview/preview-message.ts:38:7 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
-// src/dapps/preview/preview-message.ts:78:7 - (ae-forgotten-export) The symbol "EmoteEventPayload" needs to be exported by the entry point index.d.ts
+// src/dapps/preview/preview-message.ts:39:7 - (ae-incompatible-release-tags) The symbol "options" is marked as @public, but its signature references "PreviewOptions" which is marked as @alpha
+// src/dapps/preview/preview-message.ts:64:7 - (ae-forgotten-export) The symbol "EmoteEventPayload" needs to be exported by the entry point index.d.ts
 // src/dapps/rentals-listings.ts:85:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/rentals-listings.ts:126:3 - (ae-incompatible-release-tags) The symbol "network" is marked as @public, but its signature references "Network" which is marked as @alpha
 // src/dapps/rentals-listings.ts:128:3 - (ae-incompatible-release-tags) The symbol "chainId" is marked as @public, but its signature references "ChainId" which is marked as @alpha

--- a/src/dapps/preview/preview-controller.ts
+++ b/src/dapps/preview/preview-controller.ts
@@ -21,6 +21,7 @@ export type EmoteEvents = {
 
 export interface ISceneController {
   getScreenshot(width: number, height: number): Promise<string>
+  exportVRM(): Promise<void>
   getMetrics(): Promise<Metrics>
   changeZoom(zoom: number): Promise<void>
   panCamera(offset: { x?: number; y?: number; z?: number }): Promise<void>

--- a/src/dapps/preview/preview-message.ts
+++ b/src/dapps/preview/preview-message.ts
@@ -1,3 +1,4 @@
+import { IPreviewController } from '../..'
 import { JSONSchema, generateLazyValidator, ValidateFunction } from '../../validation'
 import { PreviewEmoteEventType } from './preview-emote-event-type'
 import { EmoteEventPayload } from './preview-emote-event-payload'
@@ -38,28 +39,13 @@ export type PreviewMessagePayload<T extends PreviewMessageType> = T extends Prev
   ? { options: PreviewOptions }
   : T extends PreviewMessageType.CONTROLLER_REQUEST
   ? {
-      id: string
-      namespace: 'scene' | 'emote' | 'physics'
-      method:
-        | 'getScreenshot'
-        | 'getMetrics'
-        | 'changeZoom'
-        | 'changeCameraPosition'
-        | 'panCamera'
-        | 'cleanup'
-        | 'getLength'
-        | 'isPlaying'
-        | 'play'
-        | 'pause'
-        | 'stop'
-        | 'goTo'
-        | 'enableSound'
-        | 'disableSound'
-        | 'hasSound'
-        | 'setUsername'
-        | 'setSpringBonesParams'
-      params: any[]
-    }
+      [K in keyof IPreviewController]: {
+        id: string
+        namespace: K
+        method: keyof IPreviewController[K]
+        params: any[]
+      }
+    }[keyof IPreviewController]
   : T extends PreviewMessageType.CONTROLLER_RESPONSE
   ?
       | {


### PR DESCRIPTION

**Preview Controller API Improvements:**

* The `ISceneController` interface now includes a new `exportVRM()` method, allowing scenes to be exported in VRM format. [[1]](diffhunk://#diff-bd554c2b803dd1a1b9f659c95dd4f04268a8226f77fbb5b060ce2e8efee6a5cbR24) [[2]](diffhunk://#diff-10e81da4b731b9c6ac4a7217356061eac0d9101aa12a6a87baf0516622971cc9R2731-R2732) (related PR: https://github.com/decentraland/wearable-preview/pull/180)
* The `PreviewMessagePayload` type for `CONTROLLER_REQUEST` messages is now dynamically generated from the `IPreviewController` interface. This removes the need to manually list all namespaces and methods, making the codebase easier to maintain and extend. [[1]](diffhunk://#diff-9c62369a1ea61123c9ffc0fcfb9c640dc4cf50ff9a4cca28ce95460bbf3639d0R42-R48) [[2]](diffhunk://#diff-10e81da4b731b9c6ac4a7217356061eac0d9101aa12a6a87baf0516622971cc9R4077-R4083) [[3]](diffhunk://#diff-9c62369a1ea61123c9ffc0fcfb9c640dc4cf50ff9a4cca28ce95460bbf3639d0R1)