### PR TITLE
add EVENT_DELETED event type and notification type

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -1735,7 +1735,7 @@ export namespace EthAddress {
 // Warning: (ae-missing-release-tag) "Event" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type Event_2 = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | CreditsOnDemandEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | CommunityStreamingEndedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | UserBannedFromSceneEvent | UserUnbannedFromSceneEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | CreditsNewSeasonReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberLeftEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | CommunityOwnershipTransferredEvent | CommunityPostAddedEvent | CommunityVoiceChatStartedEvent | PhotoTakenEvent | PhotoPrivacyChangedEvent | AuthIdentifyEvent | EventCreatedEvent | EventStartedEvent | EventStartsSoonEvent | EventEndedEvent | EventApprovedEvent | EventRejectedEvent | GovernanceProposalEnactedEvent | GovernanceCoauthorRequestedEvent | GovernancePitchPassedEvent | GovernanceTenderPassedEvent | GovernanceAuthoredProposalFinishedEvent | GovernanceVotingEndedVoterEvent | GovernanceNewCommentOnProposalEvent | GovernanceNewCommentOnProjectUpdatedEvent | GovernanceWhaleVoteEvent | GovernanceVotedOnBehalfEvent | GovernanceCliffEndedEvent | WorldsPermissionGrantedEvent | WorldsPermissionRevokedEvent | WorldsAccessRestoredEvent | WorldsAccessRestrictedEvent | WorldsMissingResourcesEvent | TransferReceivedEvent | TipReceivedEvent | UserBanCreatedEvent | UserBanLiftedEvent | UserWarningCreatedEvent;
+type Event_2 = BadgeGrantedEvent | BidAcceptedEvent | BidReceivedEvent | CampaignGasPriceHigherThanExpectedEvent | CampaignOutOfFundsEvent | CampaignOutOfStockEvent | CatalystDeploymentEvent | CollectionCreatedEvent | FriendshipRequestEvent | FriendshipAcceptedEvent | ItemPublishedEvent | ItemSoldEvent | LoggedInEvent | LoggedInCachedEvent | MoveToParcelEvent | PassportOpenedEvent | RentalEndedEvent | RentalStartedEvent | RewardAssignedEvent | RewardDelayedEvent | RewardInProgressEvent | RoyaltiesEarnedEvent | UsedEmoteEvent | VerticalHeightReachedEvent | WalkedDistanceEvent | CreditsGoalCompletedEvent | CreditsOnDemandEvent | StreamingKeyResetEvent | StreamingKeyRevokeEvent | StreamingKeyExpiredEvent | StreamingTimeExceededEvent | StreamingPlaceUpdatedEvent | CommunityStreamingEndedEvent | UserJoinedRoomEvent | UserLeftRoomEvent | UserBannedFromSceneEvent | UserUnbannedFromSceneEvent | CreditsCompleteGoalsReminderEvent | CreditsUsageReminderEvent | CreditsUsage24HoursReminderEvent | CreditsDoNotMissOutReminderEvent | CreditsClaimReminderEvent | CreditsNewSeasonReminderEvent | ReferralInvitedUsersAcceptedEvent | ReferralNewTierReachedEvent | CommunityDeletedEvent | CommunityDeletedContentViolationEvent | CommunityRenamedEvent | CommunityMemberBannedEvent | CommunityMemberLeftEvent | CommunityMemberRemovedEvent | CommunityRequestToJoinReceivedEvent | CommunityRequestToJoinAcceptedEvent | CommunityInviteReceivedEvent | CommunityOwnershipTransferredEvent | CommunityPostAddedEvent | CommunityVoiceChatStartedEvent | PhotoTakenEvent | PhotoPrivacyChangedEvent | AuthIdentifyEvent | EventCreatedEvent | EventStartedEvent | EventStartsSoonEvent | EventEndedEvent | EventApprovedEvent | EventRejectedEvent | EventDeletedEvent | GovernanceProposalEnactedEvent | GovernanceCoauthorRequestedEvent | GovernancePitchPassedEvent | GovernanceTenderPassedEvent | GovernanceAuthoredProposalFinishedEvent | GovernanceVotingEndedVoterEvent | GovernanceNewCommentOnProposalEvent | GovernanceNewCommentOnProjectUpdatedEvent | GovernanceWhaleVoteEvent | GovernanceVotedOnBehalfEvent | GovernanceCliffEndedEvent | WorldsPermissionGrantedEvent | WorldsPermissionRevokedEvent | WorldsAccessRestoredEvent | WorldsAccessRestrictedEvent | WorldsMissingResourcesEvent | TransferReceivedEvent | TipReceivedEvent | UserBanCreatedEvent | UserBanLiftedEvent | UserWarningCreatedEvent;
 export { Event_2 as Event }
 
 // Warning: (ae-missing-release-tag) "EventApprovedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1787,6 +1787,30 @@ export namespace EventCreatedEvent {
     schema: JSONSchema<EventCreatedEvent>;
     const // (undocumented)
     validate: ValidateFunction<EventCreatedEvent>;
+}
+
+// Warning: (ae-missing-release-tag) "EventDeletedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EventDeletedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EventDeletedEvent = BaseEvent & {
+    type: Events.Type.EVENT;
+    subType: Events.SubType.Event.EVENT_DELETED;
+    metadata: {
+        host: string;
+        title: string;
+        description: string;
+        image: string;
+        reason?: string;
+    };
+};
+
+// @public (undocumented)
+export namespace EventDeletedEvent {
+    const // (undocumented)
+    schema: JSONSchema<EventDeletedEvent>;
+    const // (undocumented)
+    validate: ValidateFunction<EventDeletedEvent>;
 }
 
 // Warning: (ae-missing-release-tag) "EventEndedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1975,6 +1999,8 @@ export namespace Events {
             EVENT_APPROVED = "event-approved",
             // (undocumented)
             EVENT_CREATED = "event-created",
+            // (undocumented)
+            EVENT_DELETED = "event-deleted",
             // (undocumented)
             EVENT_ENDED = "event-ended",
             // (undocumented)
@@ -3538,6 +3564,8 @@ export enum NotificationType {
     EVENT_APPROVED = "event_approved",
     // (undocumented)
     EVENT_CREATED = "event_created",
+    // (undocumented)
+    EVENT_DELETED = "event_deleted",
     // (undocumented)
     EVENT_REJECTED = "event_rejected",
     // (undocumented)

--- a/src/platform/events/base.ts
+++ b/src/platform/events/base.ts
@@ -73,7 +73,8 @@ import {
   EventStartsSoonEvent,
   EventEndedEvent,
   EventApprovedEvent,
-  EventRejectedEvent
+  EventRejectedEvent,
+  EventDeletedEvent
 } from './event'
 import {
   GovernanceProposalEnactedEvent,
@@ -254,7 +255,8 @@ export namespace Events {
       EVENT_STARTED = 'event-started',
       EVENT_ENDED = 'event-ended',
       EVENT_APPROVED = 'event-approved',
-      EVENT_REJECTED = 'event-rejected'
+      EVENT_REJECTED = 'event-rejected',
+      EVENT_DELETED = 'event-deleted'
     }
 
     export enum Governance {
@@ -372,6 +374,7 @@ export type Event =
   | EventEndedEvent
   | EventApprovedEvent
   | EventRejectedEvent
+  | EventDeletedEvent
   | GovernanceProposalEnactedEvent
   | GovernanceCoauthorRequestedEvent
   | GovernancePitchPassedEvent

--- a/src/platform/events/event.ts
+++ b/src/platform/events/event.ts
@@ -79,6 +79,18 @@ export type EventRejectedEvent = BaseEvent & {
   }
 }
 
+export type EventDeletedEvent = BaseEvent & {
+  type: Events.Type.EVENT
+  subType: Events.SubType.Event.EVENT_DELETED
+  metadata: {
+    host: string
+    title: string
+    description: string
+    image: string
+    reason?: string
+  }
+}
+
 export namespace EventStartedEvent {
   export const schema: JSONSchema<EventStartedEvent> = {
     type: 'object',
@@ -248,4 +260,31 @@ export namespace EventRejectedEvent {
     additionalProperties: false
   }
   export const validate: ValidateFunction<EventRejectedEvent> = generateLazyValidator(schema)
+}
+
+export namespace EventDeletedEvent {
+  export const schema: JSONSchema<EventDeletedEvent> = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', const: Events.Type.EVENT },
+      subType: { type: 'string', const: Events.SubType.Event.EVENT_DELETED },
+      key: { type: 'string' },
+      timestamp: { type: 'number', minimum: 0 },
+      metadata: {
+        type: 'object',
+        properties: {
+          host: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          image: { type: 'string' },
+          reason: { type: 'string', nullable: true }
+        },
+        required: ['host', 'title', 'image'],
+        additionalProperties: false
+      }
+    },
+    required: ['type', 'subType', 'key', 'timestamp', 'metadata'],
+    additionalProperties: false
+  }
+  export const validate: ValidateFunction<EventDeletedEvent> = generateLazyValidator(schema)
 }

--- a/src/platform/notifications/notifications.ts
+++ b/src/platform/notifications/notifications.ts
@@ -11,6 +11,7 @@ export enum NotificationType {
   EVENT_CREATED = 'event_created',
   EVENT_APPROVED = 'event_approved',
   EVENT_REJECTED = 'event_rejected',
+  EVENT_DELETED = 'event_deleted',
   GOVERNANCE_ANNOUNCEMENT = 'governance_announcement',
   GOVERNANCE_AUTHORED_PROPOSAL_FINISHED = 'governance_authored_proposal_finished',
   GOVERNANCE_COAUTHOR_REQUESTED = 'governance_coauthor_requested',

--- a/test/platform/events/event.spec.ts
+++ b/test/platform/events/event.spec.ts
@@ -1,0 +1,102 @@
+import expect from 'expect'
+import { Events, EventDeletedEvent } from '../../../src'
+
+describe('when validating EventDeletedEvent', () => {
+  describe('and all required fields are present with a reason', () => {
+    let event: EventDeletedEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.EVENT,
+        subType: Events.SubType.Event.EVENT_DELETED,
+        key: 'key',
+        timestamp: 1,
+        metadata: {
+          host: '0xhost',
+          title: 'My Hangout',
+          description: 'A hangout',
+          image: 'https://example.com/image.jpg',
+          reason: 'Removed by an administrator'
+        }
+      }
+    })
+
+    it('should pass validation', () => {
+      expect(EventDeletedEvent.validate(event)).toEqual(true)
+    })
+  })
+
+  describe('and the optional reason is omitted', () => {
+    let event: EventDeletedEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.EVENT,
+        subType: Events.SubType.Event.EVENT_DELETED,
+        key: 'key',
+        timestamp: 1,
+        metadata: {
+          host: '0xhost',
+          title: 'My Hangout',
+          description: 'A hangout',
+          image: 'https://example.com/image.jpg'
+        }
+      }
+    })
+
+    it('should pass validation', () => {
+      expect(EventDeletedEvent.validate(event)).toEqual(true)
+    })
+  })
+
+  describe('and the input is null', () => {
+    it('should fail validation', () => {
+      expect(EventDeletedEvent.validate(null)).toEqual(false)
+    })
+  })
+
+  describe('and the input is an empty object', () => {
+    it('should fail validation', () => {
+      expect(EventDeletedEvent.validate({})).toEqual(false)
+    })
+  })
+
+  describe('and host is missing from metadata', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.EVENT,
+        subType: Events.SubType.Event.EVENT_DELETED,
+        key: 'key',
+        timestamp: 1,
+        metadata: {
+          title: 'My Hangout',
+          description: 'A hangout',
+          image: 'https://example.com/image.jpg'
+        }
+      }
+    })
+
+    it('should fail validation', () => {
+      expect(EventDeletedEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and metadata is missing entirely', () => {
+    let event: any
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.EVENT,
+        subType: Events.SubType.Event.EVENT_DELETED,
+        key: 'key',
+        timestamp: 1
+      }
+    })
+
+    it('should fail validation', () => {
+      expect(EventDeletedEvent.validate(event)).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
Adds a new `EVENT_DELETED` event subtype and `EVENT_DELETED` notification type to support soft-deletion of events (hangouts).

- `Events.SubType.Event.EVENT_DELETED` (`event-deleted`) and the `EventDeletedEvent` type with its JSON schema + validator, mirroring `EventRejectedEvent` but with an optional `reason` (admin deletions may omit it).
- `NotificationType.EVENT_DELETED` (`event_deleted`) for the in-app/email notification sent to the creator when an admin deletes their event.

Consumed downstream by events (publisher), notifications-workers (parser + email template) and ui2 (bell rendering).

Verified with `npm run build`, `npm test` (833 passing), `npm run lint` and `npm run refresh-api`.