### PR TITLE
fix: bound auth chain size and link payload length

### DIFF
--- a/src/misc/auth-chain.ts
+++ b/src/misc/auth-chain.ts
@@ -39,8 +39,8 @@ export namespace AuthLink {
         type: 'string',
         enum: Object.values(AuthLinkType)
       },
-      payload: { type: 'string' },
-      signature: { type: 'string', nullable: true }
+      payload: { type: 'string', maxLength: 100000 },
+      signature: { type: 'string', nullable: true, maxLength: 100000 }
     },
     required: ['payload', 'type'],
     if: {
@@ -77,7 +77,8 @@ export namespace AuthChain {
   export const schema: JSONSchema<AuthChain> = {
     type: 'array',
     items: AuthLink.schema,
-    minItems: 1
+    minItems: 1,
+    maxItems: 10
   }
 
   export const validate: ValidateFunction<AuthChain> = generateLazyValidator(schema)


### PR DESCRIPTION
## What

`AuthChain.schema` declared `minItems: 1` but no `maxItems`, and `AuthLink` `payload`/`signature` were unbounded strings. Since `@dcl/schemas` validators gate auth on virtually every service and each link implies a costly signature recovery, an attacker could submit an arbitrarily long chain (or huge payloads) to any public endpoint that validates an auth chain and amplify CPU/memory — a DoS vector across the ecosystem.

## Change

- `AuthChain`: add `maxItems: 10` (real chains are 2-3 links; 10 is a generous bound).
- `AuthLink`: add `maxLength: 100000` to `payload` and `signature` (well above any legitimate value, bounds MB-scale payloads).

`additionalProperties: false` is intentionally **not** included here: tightening it on these schemas is a breaking change for any consumer that sends extra fields and needs ecosystem-wide coordination + a version bump. Filing separately is recommended.

## Verification

- `npm run build` (tsc) clean
- auth-chain test suite: 833 passing