### PR TITLE
feat: add optional landscapeTerrain field to Scene schema

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -4840,6 +4840,7 @@ export type Scene = DisplayableDeployment & {
     featureToggles?: FeatureToggles;
     worldConfiguration?: WorldConfiguration;
     allowedMediaHostnames?: string[];
+    landscapeTerrain?: boolean;
 };
 
 // @alpha (undocumented)

--- a/src/platform/scene/scene.ts
+++ b/src/platform/scene/scene.ts
@@ -44,6 +44,7 @@ export type Scene = DisplayableDeployment & {
   featureToggles?: FeatureToggles
   worldConfiguration?: WorldConfiguration
   allowedMediaHostnames?: string[]
+  landscapeTerrain?: boolean
 }
 
 /** @alpha */
@@ -153,6 +154,12 @@ export namespace Scene {
         items: {
           type: 'string'
         },
+        nullable: true
+      },
+      landscapeTerrain: {
+        description:
+          'Set to false to disable the auto-generated landscape terrain around the scene (applies only to Worlds with single-scene setups). Default: true (terrain shown)',
+        type: 'boolean',
         nullable: true
       }
     },

--- a/test/platform/scenes/scene.spec.ts
+++ b/test/platform/scenes/scene.spec.ts
@@ -130,6 +130,20 @@ describe('Scene tests', () => {
     })
   })
 
+  describe('test landscapeTerrain field', () => {
+    it('should return true when landscapeTerrain is not defined', () => {
+      expect(Scene.validate(scene)).toEqual(true)
+    })
+
+    it('should return true when landscapeTerrain is false', () => {
+      expect(Scene.validate(setScene(scene, { landscapeTerrain: false }))).toEqual(true)
+    })
+
+    it('should return false when landscapeTerrain is not a boolean', () => {
+      expect(Scene.validate(setScene(scene, { landscapeTerrain: 'no' }))).toEqual(false)
+    })
+  })
+
   describe('test creator field', () => {
     it('should return true when creator is not defined', () => {
       expect(Scene.validate(scene)).toEqual(true)

--- a/test/platform/scenes/scene.spec.ts
+++ b/test/platform/scenes/scene.spec.ts
@@ -139,6 +139,10 @@ describe('Scene tests', () => {
       expect(Scene.validate(setScene(scene, { landscapeTerrain: false }))).toEqual(true)
     })
 
+    it('should return true when landscapeTerrain is true', () => {
+      expect(Scene.validate(setScene(scene, { landscapeTerrain: true }))).toEqual(true)
+    })
+
     it('should return false when landscapeTerrain is not a boolean', () => {
       expect(Scene.validate(setScene(scene, { landscapeTerrain: 'no' }))).toEqual(false)
     })


### PR DESCRIPTION
Allows a scene to disable the auto-generated landscape terrain around it in the explorer (grassland, trees, sea). Optional boolean; when absent,  defaults to current behavior (terrain shown). Only honored by the explorer  in single-scene worlds and local scene development.

https://github.com/decentraland/unity-explorer/issues/6852