### PR TITLE
feat: include parcels in world scene undeployment events

### DIFF
--- a/report/schemas.api.md
+++ b/report/schemas.api.md
@@ -5941,6 +5941,7 @@ export type WorldScenesUndeploymentEvent = BaseEvent & {
         scenes: Array<{
             entityId: string;
             baseParcel: string;
+            parcels?: string[] | null;
         }>;
     };
 };

--- a/src/platform/events/world.ts
+++ b/src/platform/events/world.ts
@@ -85,6 +85,7 @@ export type WorldScenesUndeploymentEvent = BaseEvent & {
     scenes: Array<{
       entityId: string
       baseParcel: string
+      parcels?: string[] | null
     }>
   }
 }
@@ -216,7 +217,14 @@ export namespace WorldScenesUndeploymentEvent {
               type: 'object',
               properties: {
                 entityId: { type: 'string' },
-                baseParcel: PARCEL_SCHEMA
+                baseParcel: PARCEL_SCHEMA,
+                parcels: {
+                  type: 'array',
+                  items: PARCEL_SCHEMA,
+                  minItems: 1,
+                  uniqueItems: true,
+                  nullable: true
+                }
               },
               required: ['entityId', 'baseParcel'],
               additionalProperties: false

--- a/test/platform/events/world.spec.ts
+++ b/test/platform/events/world.spec.ts
@@ -427,6 +427,93 @@ describe('when validating the WorldScenesUndeploymentEvent', () => {
     })
   })
 
+  describe('and the event includes the undeployed scene footprints', () => {
+    let event: WorldScenesUndeploymentEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.WORLD_SCENES_UNDEPLOYMENT,
+        key: 'my-world.dcl.eth',
+        timestamp: 1,
+        metadata: {
+          worldName: 'my-world.dcl.eth',
+          scenes: [
+            { entityId: ENTITY_ID, baseParcel: '0,0', parcels: ['0,0', '1,0'] },
+            { entityId: ANOTHER_ENTITY_ID, baseParcel: '-1,2', parcels: ['-1,2'] }
+          ]
+        }
+      }
+    })
+
+    it('should return true', () => {
+      expect(WorldScenesUndeploymentEvent.validate(event)).toEqual(true)
+    })
+  })
+
+  describe('and an included scene footprint is empty', () => {
+    let event: WorldScenesUndeploymentEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.WORLD_SCENES_UNDEPLOYMENT,
+        key: 'my-world.dcl.eth',
+        timestamp: 1,
+        metadata: {
+          worldName: 'my-world.dcl.eth',
+          scenes: [{ entityId: ENTITY_ID, baseParcel: '0,0', parcels: [] }]
+        }
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldScenesUndeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and an included scene footprint repeats a parcel', () => {
+    let event: WorldScenesUndeploymentEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.WORLD_SCENES_UNDEPLOYMENT,
+        key: 'my-world.dcl.eth',
+        timestamp: 1,
+        metadata: {
+          worldName: 'my-world.dcl.eth',
+          scenes: [{ entityId: ENTITY_ID, baseParcel: '0,0', parcels: ['0,0', '0,0'] }]
+        }
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldScenesUndeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
+  describe('and an included scene footprint contains a non-canonical parcel', () => {
+    let event: WorldScenesUndeploymentEvent
+
+    beforeEach(() => {
+      event = {
+        type: Events.Type.WORLD,
+        subType: Events.SubType.Worlds.WORLD_SCENES_UNDEPLOYMENT,
+        key: 'my-world.dcl.eth',
+        timestamp: 1,
+        metadata: {
+          worldName: 'my-world.dcl.eth',
+          scenes: [{ entityId: ENTITY_ID, baseParcel: '0,0', parcels: ['00,0'] }]
+        }
+      }
+    })
+
+    it('should return false', () => {
+      expect(WorldScenesUndeploymentEvent.validate(event)).toEqual(false)
+    })
+  })
+
   describe('and the event is null', () => {
     it('should return false', () => {
       expect(WorldScenesUndeploymentEvent.validate(null)).toEqual(false)


### PR DESCRIPTION
## What changed
- add an optional per-scene parcel footprint to WorldScenesUndeploymentEvent
- validate included parcels as non-empty, unique, canonical coordinates
- preserve compatibility with existing events that only contain entity ID and base parcel
- refresh the public API report

## Why
Consumers need the complete footprint to durably prevent delayed deployments with a different base parcel from resurrecting content replaced upstream.

## Validation
- npm test -- --grep WorldScenesUndeploymentEvent
- npm run build
- npm run lint -- --no-fix
- npm run refresh-api