### PR TITLE
fix: bound the free-form profile avatar properties

### DIFF
--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -3,6 +3,37 @@ import { Color3, EthAddress, IPFSv2, WearableId } from '../../misc'
 import { generateLazyValidator, JSONSchema, ValidateFunction } from '../../validation'
 
 /**
+ * Bounds for the free-form avatar properties.
+ *
+ * A profile's metadata was previously unbounded in every direction: no string had a maximum
+ * length and no array had a maximum length either, so a single entry could carry megabytes.
+ * These limits are applied to already-deployed profiles whenever a node re-validates historical
+ * content, so each one is set well above the largest value real profiles are expected to hold
+ * rather than at the tightest value that would work.
+ */
+/** Longest accepted URN. The longest linked-wearable form is comfortably under this. */
+const URN_MAX_LENGTH = 256
+/** Equipped wearables, one per category, plus generous headroom. */
+const MAX_WEARABLES = 200
+/** `forceRender` holds wearable categories, so it is already bounded by that enum. */
+const MAX_FORCE_RENDER = 32
+/** Emote slots are validated to 0-9 elsewhere; this only bounds the array itself. */
+const MAX_EMOTES = 100
+/** A display name, not prose. */
+const NAME_MAX_LENGTH = 256
+/** A user-written bio. */
+const DESCRIPTION_MAX_LENGTH = 10000
+/** Short free-form profile fields such as `country`, `pronouns` or `profession`. */
+const SHORT_TEXT_MAX_LENGTH = 256
+/** The longest address an RFC 5321 mailbox may hold. */
+const EMAIL_MAX_LENGTH = 320
+/** A user id, in practice an ethereum address. */
+const USER_ID_MAX_LENGTH = 128
+/** One entry of `blocked`, `muted` or `interests`. */
+const LIST_ENTRY_MAX_LENGTH = 128
+const MAX_INTERESTS = 100
+
+/**
  * Snapshots
  * @alpha
  */
@@ -56,7 +87,8 @@ export namespace AvatarInfo {
     required: ['bodyShape', 'eyes', 'hair', 'skin'],
     properties: {
       bodyShape: {
-        type: 'string'
+        type: 'string',
+        maxLength: URN_MAX_LENGTH
       },
       eyes: {
         type: 'object',
@@ -81,22 +113,26 @@ export namespace AvatarInfo {
       },
       wearables: {
         type: 'array',
+        maxItems: MAX_WEARABLES,
         items: {
-          type: 'string'
+          type: 'string',
+          maxLength: URN_MAX_LENGTH
         }
       },
       forceRender: {
         type: 'array',
         nullable: true,
+        maxItems: MAX_FORCE_RENDER,
         items: WearableCategory.schema
       },
       emotes: {
         type: 'array',
+        maxItems: MAX_EMOTES,
         items: {
           type: 'object',
           properties: {
             slot: { type: 'number' },
-            urn: { type: 'string' }
+            urn: { type: 'string', maxLength: URN_MAX_LENGTH }
           },
           required: ['slot', 'urn']
         },
@@ -151,7 +187,8 @@ export namespace Link {
     required: ['title', 'url'],
     properties: {
       title: {
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       url: LinkUrl.schema
     }
@@ -206,17 +243,20 @@ export namespace Avatar {
     required: ['name', 'description', 'ethAddress', 'version', 'tutorialStep', 'avatar', 'hasClaimedName'],
     properties: {
       userId: {
-        type: 'string'
+        type: 'string',
+        maxLength: USER_ID_MAX_LENGTH
       },
       name: {
-        type: 'string'
+        type: 'string',
+        maxLength: NAME_MAX_LENGTH
       },
       nameColor: {
         ...Color3.schema,
         nullable: true
       },
       description: {
-        type: 'string'
+        type: 'string',
+        maxLength: DESCRIPTION_MAX_LENGTH
       },
       links: {
         type: 'array',
@@ -226,35 +266,43 @@ export namespace Avatar {
       },
       country: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       employmentStatus: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       gender: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       pronouns: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       relationshipStatus: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       sexualOrientation: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       language: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       profession: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       birthdate: {
         nullable: true,
@@ -262,11 +310,13 @@ export namespace Avatar {
       },
       realName: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       hobbies: {
         nullable: true,
-        type: 'string'
+        type: 'string',
+        maxLength: SHORT_TEXT_MAX_LENGTH
       },
       ethAddress: EthAddress.schema,
       version: {
@@ -277,26 +327,33 @@ export namespace Avatar {
       },
       email: {
         type: 'string',
-        nullable: true
+        nullable: true,
+        maxLength: EMAIL_MAX_LENGTH
       },
+      // No maxItems on blocked/muted: the lists grow with ordinary use and the safe bound
+      // depends on production data. Each entry is bounded, so the entity size cap covers them.
       blocked: {
         type: 'array',
         items: {
-          type: 'string'
+          type: 'string',
+          maxLength: LIST_ENTRY_MAX_LENGTH
         },
         nullable: true
       },
       muted: {
         type: 'array',
         items: {
-          type: 'string'
+          type: 'string',
+          maxLength: LIST_ENTRY_MAX_LENGTH
         },
         nullable: true
       },
       interests: {
         type: 'array',
+        maxItems: MAX_INTERESTS,
         items: {
-          type: 'string'
+          type: 'string',
+          maxLength: LIST_ENTRY_MAX_LENGTH
         },
         nullable: true
       },

--- a/src/platform/profile/avatar.ts
+++ b/src/platform/profile/avatar.ts
@@ -27,9 +27,20 @@ const DESCRIPTION_MAX_LENGTH = 10000
 const SHORT_TEXT_MAX_LENGTH = 256
 /** The longest address an RFC 5321 mailbox may hold. */
 const EMAIL_MAX_LENGTH = 320
-/** A user id, in practice an ethereum address. */
-const USER_ID_MAX_LENGTH = 128
-/** One entry of `blocked`, `muted` or `interests`. */
+/**
+ * A user id is an ethereum address. The pattern also accepts the empty string, which is what the
+ * deployed `defaultN` profiles carry, so constraining the field does not reject them.
+ */
+const USER_ID_PATTERN = '^(0x[a-fA-F0-9]{40})?$'
+/** `blocked` and `muted` hold user ids, so an entry is at most an address. */
+const ETH_ADDRESS_MAX_LENGTH = 42
+/**
+ * `blocked` and `muted` grow with ordinary use, so this is set far above any observed list rather
+ * than at the tightest workable value: no profile in a sample of recent deployments held a single
+ * entry in either.
+ */
+const MAX_BLOCKED_OR_MUTED = 5000
+/** One entry of `interests`. */
 const LIST_ENTRY_MAX_LENGTH = 128
 const MAX_INTERESTS = 100
 
@@ -244,7 +255,7 @@ export namespace Avatar {
     properties: {
       userId: {
         type: 'string',
-        maxLength: USER_ID_MAX_LENGTH
+        pattern: USER_ID_PATTERN
       },
       name: {
         type: 'string',
@@ -330,21 +341,21 @@ export namespace Avatar {
         nullable: true,
         maxLength: EMAIL_MAX_LENGTH
       },
-      // No maxItems on blocked/muted: the lists grow with ordinary use and the safe bound
-      // depends on production data. Each entry is bounded, so the entity size cap covers them.
       blocked: {
         type: 'array',
+        maxItems: MAX_BLOCKED_OR_MUTED,
         items: {
           type: 'string',
-          maxLength: LIST_ENTRY_MAX_LENGTH
+          maxLength: ETH_ADDRESS_MAX_LENGTH
         },
         nullable: true
       },
       muted: {
         type: 'array',
+        maxItems: MAX_BLOCKED_OR_MUTED,
         items: {
           type: 'string',
-          maxLength: LIST_ENTRY_MAX_LENGTH
+          maxLength: ETH_ADDRESS_MAX_LENGTH
         },
         nullable: true
       },

--- a/src/platform/profile/profile.ts
+++ b/src/platform/profile/profile.ts
@@ -1,7 +1,7 @@
 import { generateLazyValidator, JSONSchema, ValidateFunction } from '../../validation'
 import { Avatar } from './avatar'
 
-const MAX_AVATARS = 10
+const MAX_AVATARS = 1
 
 /**
  * Profile containing one or multiple avatars
@@ -22,7 +22,7 @@ export namespace Profile {
     properties: {
       avatars: {
         type: 'array',
-        // Deployed profiles carry a single avatar; the bound is headroom, not the expected shape.
+        // Deployed profiles carry exactly one avatar; consumers only ever read `avatars[0]`.
         maxItems: MAX_AVATARS,
         items: Avatar.schema
       }

--- a/src/platform/profile/profile.ts
+++ b/src/platform/profile/profile.ts
@@ -1,6 +1,8 @@
 import { generateLazyValidator, JSONSchema, ValidateFunction } from '../../validation'
 import { Avatar } from './avatar'
 
+const MAX_AVATARS = 10
+
 /**
  * Profile containing one or multiple avatars
  * @alpha
@@ -20,6 +22,8 @@ export namespace Profile {
     properties: {
       avatars: {
         type: 'array',
+        // Deployed profiles carry a single avatar; the bound is headroom, not the expected shape.
+        maxItems: MAX_AVATARS,
         items: Avatar.schema
       }
     },

--- a/test/platform/profiles/avatar.spec.ts
+++ b/test/platform/profiles/avatar.spec.ts
@@ -230,11 +230,11 @@ describe('Avatar tests', () => {
     })
   })
 
-  describe('when the avatar has a blocked entry over the maximum length', () => {
+  describe('when the avatar has a blocked entry longer than an ethereum address', () => {
     let avatar: Avatar
 
     beforeEach(() => {
-      avatar = { ...AVATAR, blocked: ['x'.repeat(129)] }
+      avatar = { ...AVATAR, blocked: ['0x' + 'a'.repeat(41)] }
     })
 
     it('should return false', () => {
@@ -242,14 +242,62 @@ describe('Avatar tests', () => {
     })
   })
 
-  describe('when the avatar has a large but individually bounded blocked list', () => {
+  describe('when the avatar has a blocked list at the maximum length', () => {
     let avatar: Avatar
 
     beforeEach(() => {
       avatar = { ...AVATAR, blocked: Array.from({ length: 5000 }, () => '0x' + 'a'.repeat(40)) }
     })
 
-    it('should return true because the list length is bounded by the entity size cap instead', () => {
+    it('should return true', () => {
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar has a blocked list over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, blocked: Array.from({ length: 5001 }, () => '0x' + 'a'.repeat(40)) }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a muted list over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, muted: Array.from({ length: 5001 }, () => '0x' + 'a'.repeat(40)) }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a userId that is not an ethereum address', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, userId: 'not-an-address' }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has an empty userId as the default profiles do', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, userId: '' }
+    })
+
+    it('should return true', () => {
       expect(Avatar.validate(avatar)).toEqual(true)
     })
   })

--- a/test/platform/profiles/avatar.spec.ts
+++ b/test/platform/profiles/avatar.spec.ts
@@ -193,4 +193,97 @@ describe('Avatar tests', () => {
       expect(Avatar.validate(avatar)).toEqual(false)
     })
   })
+
+  describe('when the avatar has a description at the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, description: 'x'.repeat(10000) }
+    })
+
+    it('should return true', () => {
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar has a description over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, description: 'x'.repeat(10001) }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a name over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, name: 'x'.repeat(257) }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a blocked entry over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, blocked: ['x'.repeat(129)] }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a large but individually bounded blocked list', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = { ...AVATAR, blocked: Array.from({ length: 5000 }, () => '0x' + 'a'.repeat(40)) }
+    })
+
+    it('should return true because the list length is bounded by the entity size cap instead', () => {
+      expect(Avatar.validate(avatar)).toEqual(true)
+    })
+  })
+
+  describe('when the avatar has more wearables than the maximum allowed', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = {
+        ...AVATAR,
+        avatar: {
+          ...AVATAR_INFO,
+          wearables: Array.from({ length: 201 }, (_, i) => `urn:decentraland:off-chain:base-avatars:w${i}`)
+        }
+      }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
+
+  describe('when the avatar has a wearable urn over the maximum length', () => {
+    let avatar: Avatar
+
+    beforeEach(() => {
+      avatar = {
+        ...AVATAR,
+        avatar: { ...AVATAR_INFO, wearables: ['urn:decentraland:off-chain:base-avatars:' + 'w'.repeat(256)] }
+      }
+    })
+
+    it('should return false', () => {
+      expect(Avatar.validate(avatar)).toEqual(false)
+    })
+  })
 })

--- a/test/platform/profiles/profile.spec.ts
+++ b/test/platform/profiles/profile.spec.ts
@@ -23,3 +23,15 @@ describe('Profile tests', () => {
     expect(validate.errors![0].message).toEqual("must have required property 'avatars'")
   })
 })
+
+describe('when the profile has more than one avatar', () => {
+  let profile: Profile
+
+  beforeEach(() => {
+    profile = { avatars: [AVATAR, AVATAR] }
+  })
+
+  it('should return false', () => {
+    expect(Profile.validate(profile)).toEqual(false)
+  })
+})


### PR DESCRIPTION
## Problem

A profile's metadata is unbounded in every direction. Not one string in `Avatar` or `AvatarInfo` carries a `maxLength`, and not one array carries a `maxItems`, so a single field can hold megabytes:

```
ABUSE: one 10MB description         10240.4 KB
ABUSE: one 10MB blocked entry       10240.5 KB
ABUSE: 10MB junk in a wearable urn  10240.4 KB
```

All three validate against the current schema. `links` was the only bounded field, with `maxItems: 5` and a `maxLength` on the url.

## Change

Every free-form string is bounded, and the arrays whose length is structurally justified are bounded too. After this change all three cases above are rejected, while a realistic profile and a heavy-but-real one both still pass:

```
  accepted        0.5 KB   realistic profile
  accepted      132.3 KB   heavy: 3000 blocked entries
  REJECTED    10240.4 KB   ABUSE: one 10MB description
  REJECTED    10240.5 KB   ABUSE: one 10MB blocked entry
  REJECTED    10240.4 KB   ABUSE: 10MB junk in a wearable urn
```

| Property | Limit |
| --- | --- |
| `description` | 10000 |
| `name`, `country`, `pronouns`, `profession`, `realName`, `hobbies`, and the other short fields, `Link.title` | 256 |
| `email` | 320 (RFC 5321) |
| `userId` | 128 |
| `bodyShape`, `wearables[]`, `emotes[].urn` | 256 |
| `blocked[]`, `muted[]`, `interests[]` entries | 128 |
| `wearables` | 200 items |
| `emotes` | 100 items |
| `interests` | 100 items |
| `forceRender` | 32 items |
| `Profile.avatars` | 10 items |

## Why the limits are generous rather than tight

`metadataSchemaValidateFn` in `@dcl/content-validator` is gated on ADR-45, and `ADRMetadataVersionTimelines.profile` is empty, so there is no per-timestamp schema selection for profiles. These constraints are therefore applied to already-deployed profiles whenever a node re-validates historical content while bootstrapping. A limit set at the tightest value that would work today would retroactively reject profiles that were valid when they were deployed, stranding them in failed deployments.

Every limit is set well above the largest value a real profile is expected to hold. The existing 869 tests pass unchanged, which is a first signal that no realistic fixture violates them.

## Why `blocked` and `muted` keep no `maxItems`

Both grow with ordinary use — they are lists of user ids, and unity-explorer writes `blocked` into the deployed profile with no client-side cap — so a long-lived account can legitimately hold thousands. At roughly 45 bytes per entry, 3000 blocked plus 3000 muted is about 267 KB of entity. Any `maxItems` here is a guess without production data, and guessing wrong silently breaks a real user's profile deployment forever.

Bounding each entry instead makes their growth linear and predictable, which leaves the entity size cap as the right place to bound the total. decentraland/core-libs#67 adds that cap.

## What this does not do

It does not make a profile's size finite. `additionalProperties: true` on `Profile`, `Avatar` and `AvatarInfo` means unknown keys stay unbounded, so the schema alone can never be the size bound — that has to be the entity size cap. The value here is removing the single-field vectors, so that what reaches a consumer has a shape worth reasoning about.

## Notes for review

The limits are reasoned from the shape of the data, not measured against production. If the distribution of real profile field sizes is available, `description` and `Profile.avatars` are the two worth checking before merge — every limit is a one-line constant in `avatar.ts`.

Worth deciding explicitly: this tightens validation on a published schema, so documents that were valid become invalid. Given content-validator applies schemas retroactively, you may want this to go out as a major rather than a patch, the way the scene identity enforcement did in 27.0.0.
